### PR TITLE
Limiting the maximum stage 1 lift distance

### DIFF
--- a/dual_voc_sensor.py
+++ b/dual_voc_sensor.py
@@ -45,12 +45,12 @@ class SensorDataHandler:
                 self.calibration_data[temp] = calib
                 calibration_changed = True
 
-            logging.info(f"Raw: {meas}, Calib: {calib}, Temp: {temp}")
+            #logging.info(f"Raw: {meas}, Calib: {calib}, Temp: {temp}")
 
             f = 100 / (calib - self.lower_threshold)
             meas = (meas - self.lower_threshold) * f
 
-            logging.info(f"Factor: {f}, Normalized: {meas}")
+            #logging.info(f"Factor: {f}, Normalized: {meas}")
 
             self.normalized_data[temp] = round( meas,2)
 

--- a/dual_voc_sensor.py
+++ b/dual_voc_sensor.py
@@ -229,21 +229,12 @@ class DualVocSensor:
         calib_changed &= changed[1]
 
         if data_changed:
-            logging.info("Storing Data")
-            #self.store_data()
-
             if self.enable_respond:
                 self.dummy_gcode_cmd.respond_raw(f"VOCINLET:{self.inlet_calib.get_air_quality_indicator()[1]}")
                 self.dummy_gcode_cmd.respond_raw(f"VOCOUTLET:{self.outlet_calib.get_air_quality_indicator()[1]}")
 
-
-        #if calib_changed:
-        #    logging.info("Storing Calibration")
-        #    self.store_calib()
-
-
         measured_time = self.reactor.monotonic()
-        return measured_time + 1
+        return measured_time + 5
 
     def store_data(self):
         inlet_data = self.inlet_calib.get_measurement_data_for_export()

--- a/dual_voc_sensor.py
+++ b/dual_voc_sensor.py
@@ -255,6 +255,10 @@ class DualVocSensor:
 
         self.writer.submit("calib", out)
 
+    def get_status(self, eventtime):
+        return {
+            'none': True
+        }
 
 def load_config(config):
     return DualVocSensor(config)

--- a/dual_voc_sensor.py
+++ b/dual_voc_sensor.py
@@ -203,6 +203,8 @@ class DualVocSensor:
         self.printer.register_event_handler("klippy:connect",
                                             self._handle_connect)
 
+        self.printer.register_event_handler("klippy:shutdown", self._handle_shutdown)
+
 
     def _handle_connect(self):
 
@@ -212,6 +214,9 @@ class DualVocSensor:
         self.sample_timer = self.reactor.register_timer(self._sample_voc)
         self.reactor.update_timer(self.sample_timer, self.reactor.NOW)
 
+    def _handle_shutdown(self):
+        self.store_data()
+        self.store_calib()
 
     def _sample_voc(self,eventtime):
 
@@ -225,16 +230,16 @@ class DualVocSensor:
 
         if data_changed:
             logging.info("Storing Data")
-            self.store_data()
+            #self.store_data()
 
             if self.enable_respond:
                 self.dummy_gcode_cmd.respond_raw(f"VOCINLET:{self.inlet_calib.get_air_quality_indicator()[1]}")
                 self.dummy_gcode_cmd.respond_raw(f"VOCOUTLET:{self.outlet_calib.get_air_quality_indicator()[1]}")
 
 
-        if calib_changed:
-            logging.info("Storing Calibration")
-            self.store_calib()
+        #if calib_changed:
+        #    logging.info("Storing Calibration")
+        #    self.store_calib()
 
 
         measured_time = self.reactor.monotonic()

--- a/dual_voc_sensor.py
+++ b/dual_voc_sensor.py
@@ -3,6 +3,77 @@ import logging
 import os.path
 import time
 from json import JSONDecodeError
+import json
+import os
+import queue
+import tempfile
+import threading
+from typing import Dict, Any, Union
+
+
+class AsyncJSONFileWriter:
+    """
+    Offload JSON-encoded writes to a background thread.
+    - Use submit('file1', data) / submit('file2', data) to enqueue writes.
+    - Files are overwritten atomically (temp file + os.replace).
+    - Main thread remains non-blocking.
+    """
+
+    def __init__(self, file_map: Dict[str, Union[str, os.PathLike]], flush: bool = True):
+        """
+        file_map: e.g. {'file1': 'path/to/file1.json', 'file2': 'path/to/file2.json'}
+        flush: fsync writes for extra durability
+        """
+        self._paths = {k: os.fspath(v) for k, v in file_map.items()}
+        self._q: "queue.Queue[tuple[str, Any]]" = queue.Queue()
+        self._stop = threading.Event()
+        self._flush = flush
+        self._worker = threading.Thread(target=self._run, name="AsyncJSONFileWriter", daemon=True)
+        self._worker.start()
+
+    def submit(self, target: str, data: Any) -> None:
+        """Queue a write to the given target key from file_map."""
+        if target not in self._paths:
+            raise KeyError(f"Unknown target '{target}'. Valid: {list(self._paths)}")
+        # put_nowait keeps caller non-blocking (queue is unbounded)
+        self._q.put_nowait((target, data))
+
+    def _run(self) -> None:
+        while not self._stop.is_set() or not self._q.empty():
+            try:
+                target, data = self._q.get(timeout=0.1)
+            except queue.Empty:
+                continue
+
+            path = self._paths[target]
+            payload = json.dumps(data, ensure_ascii=False)  # UTF-8 friendly
+            dirn = os.path.dirname(path) or "."
+
+            # Write to a temp file then replace -> atomic overwrite
+            fd, tmp = tempfile.mkstemp(prefix=".tmp_asyncwrite_", dir=dirn)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(payload)
+                    if self._flush:
+                        f.flush()
+                        os.fsync(f.fileno())
+                os.replace(tmp, path)  # atomic on POSIX/Windows (same filesystem)
+            finally:
+                # If an exception occurred before replace, ensure temp file is removed
+                if os.path.exists(tmp):
+                    try:
+                        os.remove(tmp)
+                    except OSError:
+                        pass
+                self._q.task_done()
+
+    def stop(self, wait: bool = True) -> None:
+        """Signal the worker to stop. If wait=True, drain the queue before joining."""
+        self._stop.set()
+        if wait:
+            self._q.join()
+        self._worker.join(timeout=2)
+
 
 class SensorDataHandler:
 
@@ -45,12 +116,8 @@ class SensorDataHandler:
                 self.calibration_data[temp] = calib
                 calibration_changed = True
 
-            #logging.info(f"Raw: {meas}, Calib: {calib}, Temp: {temp}")
-
             f = 100 / (calib - self.lower_threshold)
             meas = (meas - self.lower_threshold) * f
-
-            #logging.info(f"Factor: {f}, Normalized: {meas}")
 
             self.normalized_data[temp] = round( meas,2)
 
@@ -86,6 +153,7 @@ class SensorDataHandler:
 
     def get_calibration_data_for_export(self):
         return self.calibration_data
+
 
 class DualVocSensor:
 
@@ -126,6 +194,11 @@ class DualVocSensor:
         else:
             self.inlet_calib = SensorDataHandler.empty()
             self.outlet_calib = SensorDataHandler.empty()
+
+        self.writer = AsyncJSONFileWriter({
+            "calib": self.calib_storage_path,
+            "data": self.data_storage_path,
+        })
 
         self.printer.register_event_handler("klippy:connect",
                                             self._handle_connect)
@@ -175,8 +248,7 @@ class DualVocSensor:
         out["inlet"] = inlet_data
         out["outlet"] = outlet_data
 
-        with open(self.data_storage_path, "w") as f:
-            json.dump(out, f)
+        self.writer.submit("data", out)
 
     def store_calib(self):
         inlet_calibration_values = self.inlet_calib.get_calibration_data_for_export()
@@ -185,8 +257,8 @@ class DualVocSensor:
         out["inlet"] = inlet_calibration_values
         out["outlet"] = outlet_calibration_values
 
-        with open(self.calib_storage_path, "w") as f:
-            json.dump(out, f)
+        self.writer.submit("calib", out)
+
 
 def load_config(config):
     return DualVocSensor(config)

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -214,10 +214,12 @@ class PrinterFssProbe:
     def run_probe_downwards(self, gcmd):
         dip_speed = gcmd.get_float("F", self.lift_speed, above=0.) / 60
         dip_amount = gcmd.get_float("Z", 0, minval=0.)
+        move_absolute = gcmd.get_int("ABS",0, minval=0, maxval=1)
         toolhead = self.printer.lookup_object('toolhead')
         pos = toolhead.get_position()
 
-        #logging.info("Toolhead Position:",pos[2])
+        if move_absolute == 1:
+            dip_amount = (pos[2] - dip_amount) *-1
 
         if dip_amount == 0:
             dip_amount = -1*pos[2]

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -52,7 +52,7 @@ class PrinterFssProbe:
         self.resin_temp_setpoint = 0.0
         self.resinheater = None
 
-        self.peelmode = "minimal"
+        self.kinematic_mode = "minimal"
 
         self.expose_processing_delay = 0.300
 
@@ -119,16 +119,19 @@ class PrinterFssProbe:
         self.gcode.register_command('SET_Z_OFFSET', self.cmd_SET_Z_OFFSET,
                                     desc=self.cmd_SET_Z_OFFSET_help)
 
-        self.gcode.register_command('ATHENA_SET_PEELMODE_MINIMAL', self.cmd_ATHENA_SET_PEELMODE_MINIMAL)
+        self.gcode.register_command('ATHENA_SET_KINEMATIC_MODE_MINIMAL', self.cmd_ATHENA_SET_KINEMATIC_MODE_MINIMAL)
 
-        self.gcode.register_command('ATHENA_SET_PEELMODE_FULL', self.cmd_ATHENA_SET_PEELMODE_FULL)
+        self.gcode.register_command('ATHENA_SET_KINEMATIC_MODE_FULL', self.cmd_ATHENA_SET_KINEMATIC_MODE_FULL)
+        self.gcode.register_command('ATHENA_SET_KINEMATIC_MODE', self.cmd_ATHENA_SET_KINEMATIC_MODE)
+
+
 
         self.gcode.register_command('ATHENA_SET_MINIMUM_LIFT_DISTANCE', self.cmd_ATHENA_SET_MINIMUM_LIFT_DISTANCE)
 
         self.gcode.register_command('ATHENA_SET_FULL_LIFT_SPEED', self.cmd_ATHENA_SET_FULL_LIFT_SPEED)
 
-        self.gcode.register_command('ATHENA_SMART_DIP', self.cmd_ATHENA_SMART_DIP)
-        self.gcode.register_command('ATHENA_SMART_PEEL', self.cmd_ATHENA_SMART_PEEL)
+        self.gcode.register_command('ATHENA_DIP', self.cmd_ATHENA_DIP)
+        self.gcode.register_command('ATHENA_PEEL', self.cmd_ATHENA_PEEL)
 
     def setup_pin(self, pin_type, pin_params):
         if pin_type != 'endstop' or pin_params['pin'] != 'z_virtual_endstop':
@@ -235,7 +238,7 @@ class PrinterFssProbe:
 
         kinematics.set_accel_decel(saved_accel_decel)
 
-        if self.peelmode == "minimal":
+        if self.kinematic_mode == "minimal":
             if pos[2] < self.min_lift_distance:
                 logging.info("Minimum lift distance not reached: %f required: %f", pos[2], self.min_lift_distance)
                 pos_actual = self._get_position()
@@ -249,7 +252,7 @@ class PrinterFssProbe:
                 else:
                     logging.info("Skipping due to hysteresis")
 
-        elif self.peelmode == "full":
+        elif self.kinematic_mode == "full":
             logging.info("Peel finished after %f", pos[2])
             pos_actual = self._get_position()
             already_travelled = stage1_lift_distance + pos[2]
@@ -315,36 +318,25 @@ class PrinterFssProbe:
         pos = self._get_position()
         layer_position = pos[2]
 
-        estimated_lift_distance = 4 + min(4,2/modulus_gpa)
-        actual_lift_distance = max(lift_total,estimated_lift_distance)
-
-        logging.warning(f"Smart Peel Using {actual_lift_distance}mm Lift")
-
-        if layer_position < effective_resin_level:
-            actual_lift_distance = round(actual_lift_distance + (lift_total / 3))
-
-        #stage1_distance = min(actual_lift_distance - 1, max(1, round(actual_lift_distance / 3 * modulus_gpa ,1) ))
-        stage1_distance = min(actual_lift_distance - 1, max(1, round(actual_lift_distance / (3 * modulus_gpa), 1)))
-
-        stage2_distance = actual_lift_distance - stage1_distance
+        stage1_distance = min(lift_total - 1, max(1, round(lift_total / pow(3 * modulus_gpa, 2 / 3), 1)))
+        stage2_distance = lift_total - stage1_distance
 
         logging.warning(f"Smart Peel first calc run: S1D: {stage1_distance} | S2D: {stage2_distance}")
 
         if layer_position < effective_resin_level:
             speed = lift_speed/2
-            stage1_distance = max(stage1_distance, round(actual_lift_distance/2, 2))
+            #stage1_distance = max(stage1_distance, round(actual_lift_distance/2, 2))
 
         else:
             areaRatio = largest_surface_area_mm2 / self.buildplate_area
             areaFactor = pow(areaRatio, 1 / 4)
-            #minSpeed = max(stage1_max_speed, lift_speed * (1 - 1/2 * modulus_gpa)) #matteos version
-            minSpeed = max(stage1_max_speed, lift_speed * (modulus_gpa / 6 + 1 / 2))#jacobis version
+            minSpeed = max(stage1_max_speed, lift_speed * (modulus_gpa / 6 + 1/2))
             stage2_distance = round((1 + stage2_distance * areaFactor),1)
             speed = round((minSpeed + (lift_speed - minSpeed) * (1-areaFactor)) , 2)
 
 
         #stage1Speed = max(stage1_min_speed, round(speed * 0.15 * (1 / modulus_gpa),2)) #matteos version
-        stage1Speed = max(stage1_min_speed, round(speed ** 2 / lift_speed * modulus_gpa, 2)) #jacobis version
+        stage1Speed = max(stage1_min_speed, round(speed ** 2 / lift_speed * 1 / 2, 2)) #jacobis version (corrected on 6.3.)
 
         stage1Speed = min(stage1_max_speed,stage1Speed)
         stage2Speed = max(stage2_min_speed, speed)
@@ -467,19 +459,16 @@ class PrinterFssProbe:
         toolhead = self.printer.lookup_object('toolhead')
         pos = self._get_position()
         dip_amount = pos[2] - target_position
+
+        dip_first_stage = dip_amount * 0.8
+        dip_second_stage = dip_amount - dip_first_stage
+
+
         d_d = max(0.1,(0.218*((surface_area_mm2*pressure_gfmm2)**0.821)) / 1000)    # maximum arm deflection from retract force on layer area
-        d_d2 = max(0.1,(0.218*((max_force)**0.821)) / 1000) # maximum arm deflection due to force on build plate
+        d_d2 = max(0.1, (0.218 * (max_force ** 0.821)) / 1000) # maximum arm deflection due to force on build plate
         logging.info(f"Actual Dip Amount {dip_amount}, Target Z {target_position}")
 
-        if target_position < 0.5:
-            deflection = ((d_d2*ilaC)*(1-(target_position*2))+((d_d*ilaC)*(target_position*2)))
-        else:
-            deflection = (d_d*ilaC)
-
-        deflection = 0
-
-        segments = max(1., math.floor((dip_amount+deflection) / resolution))
-        logging.info(f"Deflection {deflection}, Segments {segments}")
+        segments = max(1., math.floor(dip_second_stage / resolution))
 
         if target_position < resin_level_mm:
             for i in range(1, int(segments) + 1):
@@ -531,6 +520,30 @@ class PrinterFssProbe:
 
     cmd_PROBE_help = "Probe Z-height at current XY position"
 
+    def cmd_ATHENA_DIP(self,gcmd):
+        if self.kinematic_mode != "smart":
+            target_position = gcmd.get_float("TARGET", minval=0.)
+            target_speed = gcmd.get_float("SPEED", minval=0.) / 60.0
+            pos = [0,0,target_position]
+            self._move(pos,target_speed)
+            self.toolhead.wait_moves()
+
+        else:
+            self.smart_dip(gcmd)
+
+        gcmd.respond_raw("Z_move_comp")
+
+    def cmd_ATHENA_PEEL(self,gcmd):
+        if self.kinematic_mode != "smart":
+            pos = self.run_probe_upwards(gcmd)
+        else:
+            pos = self.smart_peel(gcmd)
+
+        gcmd.respond_raw("Z_move_comp")
+        gcmd.respond_info("Result is z=%.6f" % (pos[2],))
+        self.last_z_result = pos[2]
+
+
     def cmd_ATHENA_SMART_DIP(self,gcmd):
         self.smart_dip(gcmd)
         gcmd.respond_raw("Z_move_comp")
@@ -540,7 +553,6 @@ class PrinterFssProbe:
         gcmd.respond_raw("Z_move_comp")
         gcmd.respond_info("Result is z=%.6f" % (pos[2],))
         self.last_z_result = pos[2]
-
 
 
     def cmd_ATHENA_PROBE_UPWARDS(self, gcmd):
@@ -565,11 +577,22 @@ class PrinterFssProbe:
     def cmd_ATHENA_OVERRIDE_RESINLEVEL(self, gcmd):
         self.last_resin_level = gcmd.get_float("LEVEL", above=0.)  # from resin profile
 
-    def cmd_ATHENA_SET_PEELMODE_MINIMAL(self, gcmd):
-        self.peelmode="minimal"
+    def cmd_ATHENA_SET_KINEMATIC_MODE_MINIMAL(self, gcmd):
+        self.kinematic_mode= "minimal"
 
-    def cmd_ATHENA_SET_PEELMODE_FULL(self, gcmd):
-        self.peelmode="full"
+    def cmd_ATHENA_SET_KINEMATIC_MODE_FULL(self, gcmd):
+        self.kinematic_mode= "full"
+
+    def cmd_ATHENA_SET_KINEMATIC_MODE(self, gcmd):
+        mode = gcmd.get_int("MODE")
+        if mode == 0:
+            self.kinematic_mode = "minimal"
+        elif mode == 1:
+            self.kinematic_mode = "full"
+        elif mode == 2:
+            self.kinematic_mode = "smart"
+        else:
+            self.kinematic_mode = "full"
 
     def cmd_ATHENA_SET_MINIMUM_LIFT_DISTANCE(self, gcmd):
         self.min_lift_distance = gcmd.get_float("VALUE", self.lift_amount, minval=0.)

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -363,7 +363,7 @@ class PrinterFssProbe:
 
         # constant factors for generating velocity profile
         resolution = 0.005 # similar to g2 gcode
-        vmin = 0.005 # minimum velocity 0.3mm/min
+        vmin = 0.05 # minimum velocity 0.3mm/min
         vmax = 10   # maximum velocity 600mm/min
         max_force = 20000 #maximum force a retract move will try to achieve
         viscosity_coefficient = 60   #constant for movements outside of squeezing flow regime

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -379,13 +379,17 @@ class PrinterFssProbe:
         d_d2 = max(0.1,(0.218*((max_force)**0.821)) / 1000) # maximum arm deflection due to force on build plate
         logging.info(f"Actual Dip Amount {dip_amount}, Target Z {target_position}")
 
-        if (target_position < 0.5):
+        if target_position < 0.5:
             deflection = ((d_d2*ilaC)*(1-(target_position*2))+((d_d*ilaC)*(target_position*2)))
             segments = max(1., math.floor((dip_amount+deflection) / resolution))
+            logging.info(f"Deflection {deflection}, Segments {segments}")
         else:
             deflection = (d_d*ilaC)
             segments = max(1., math.floor((dip_amount+deflection) / resolution))
-        if (target_position < resin_level_mm):
+
+        logging.info(f"Deflection {deflection}, Segments {segments}")
+
+        if target_position < resin_level_mm:
             for i in range(1, int(segments) + 1):
                 step_pos = [0. , 0. , 0. , 0.]
                 step_pos[2] =  pos[2] - (i * resolution)

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -343,12 +343,15 @@ class PrinterFssProbe:
         target_position = gcmd.get_float("TARGET", minval=0.)
 
         # constant factors for generating velocity profile
-        resolution = 0.01 # similar to g2 gcode
-        vmin = 0.02 # minimum velocity 1.2mm/min
+        resolution = 0.005 # similar to g2 gcode
+        vmin = 0.005 # minimum velocity 0.3mm/min
         vmax = 10   # maximum velocity 600mm/min
         max_force = 20000 #maximum force a retract move will try to achieve
         viscosity_coefficient = 60   #constant for movements outside of squeezing flow regime
-        pressure_mpa_maxforce = (max_force/buildplate_area_mm2)/mPa_to_gfmm2    #pressure on build plate corresponding to maximum force
+        e_plate_area = buildplate_area_mm2 * 0.75 # the circular eqiuvalent area which produces the same constant pressure curve
+        pressure_mpa_maxforce = (max_force/e_plate_area)/mPa_to_gfmm2    #pressure on build plate corresponding to maximum force
+        ilaC = 0.5 #Initial layer accuracy coefficient, determines the amount of overshoot on the first layers for better layer thickness accuracy, increases first layer time
+
 
         toolhead = self.printer.lookup_object('toolhead')
         pos = self._get_position()
@@ -357,16 +360,20 @@ class PrinterFssProbe:
         d_d2 = max(0.1,(0.218*((max_force)**0.821)) / 1000) # maximum arm deflection due to force on build plate
         logging.info(f"Actual Dip Amount {dip_amount}, Target Z {target_position}")
 
-
-        segments = max(1., math.floor(dip_amount / resolution))
+        if (target_position < 0.5):
+            deflection = ((d_d2*ilaC)*(1-(target_position*2))+((d_d*ilaC)*(target_position*2)))
+            segments = max(1., math.floor((dip_amount+deflection) / resolution))
+        else:
+            deflection = (d_d*ilaC)
+            segments = max(1., math.floor((dip_amount+deflection) / resolution))
         if (target_position < resin_level_mm):
             for i in range(1, int(segments) + 1):
                 step_pos = [0. , 0. , 0. , 0.]
                 step_pos[2] =  pos[2] - (i * resolution)
                 di = dip_amount + layerheight_mm - (i*resolution)
                 # velocity = minimum of velocity for maximum part pressure or velocity corresponding with maximum force
-                v1 = (6*(pressure_mpa*math.pi*2*(d_d+di)**3)/(3*viscosity_cps*surface_area_mm2))*(1 + (viscosity_coefficient*math.atan(((di)+d_d)/(math.sqrt(surface_area_mm2/math.pi)))))
-                v2 = (6*(pressure_mpa_maxforce*math.pi*2*(d_d2+di)**3)/(3*viscosity_cps*buildplate_area_mm2))*(1 + (viscosity_coefficient*math.atan(((di)+d_d2)/(math.sqrt(buildplate_area_mm2/math.pi)))))
+                v1 = (3*(pressure_mpa*math.pi*2*(d_d+di)**3)/(3*viscosity_cps*surface_area_mm2))*(1 + (viscosity_coefficient*math.atan(((di)+d_d)/(math.sqrt(surface_area_mm2/math.pi)))))
+                v2 = ((pressure_mpa_maxforce*math.pi*2*(d_d2+di)**3)/(3*viscosity_cps*e_plate_area))*(1 + (viscosity_coefficient*math.atan(((di)+d_d2)/(math.sqrt(e_plate_area/math.pi)))))
                 v3 = min(v1,v2)
                 velocity = min(max(v3,vmin),vmax)
                 self._move(step_pos,velocity)
@@ -376,17 +383,13 @@ class PrinterFssProbe:
                 step_pos = [0. , 0. , 0. , 0.]
                 step_pos[2] =  pos[2] - (i * resolution)
                 di = dip_amount + layerheight_mm - (i*resolution)
-                v1 = (6*(pressure_mpa*math.pi*2*(d_d+(di))**3)/(3*viscosity_cps*surface_area_mm2))*(1 + (viscosity_coefficient*math.atan(((di)+d_d)/(math.sqrt(surface_area_mm2/math.pi)))))
+                v1 = (3*(pressure_mpa*math.pi*2*(d_d+di)**3)/(3*viscosity_cps*surface_area_mm2))*(1 + (viscosity_coefficient*math.atan(((di)+d_d)/(math.sqrt(surface_area_mm2/math.pi)))))
                 velocity = min(max(v1,vmin),vmax)
                 self._move(step_pos,velocity)
+
+        self._move([0,0,target_position,0],5)
         toolhead.wait_moves()
         pos = self._get_position()
-
-        # function that removes any error on final position due to segmentation resolution
-        if (pos[2] != target_position):
-            self._move([0,0,target_position,0],velocity)
-            toolhead.wait_moves()
-            pos = self._get_position()
 
         return pos
 
@@ -494,7 +497,7 @@ class PrinterFssProbe:
     def cmd_SET_Z_OFFSET(self,gcmd):
         self.z_offset = gcmd.get_float("OFFSET", 0 , minval=0. )
 
-    cmd_EXPOSE_help = "Exposes a layer for a given time with a given PWM setting"
+    cmd_SET_Z_OFFSET_help = "Exposes a layer for a given time with a given PWM setting"
     def cmd_EXPOSE(self, gcmd):
 
         if self.exposure_active_flag:

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -49,6 +49,9 @@ class PrinterFssProbe:
 
         self.expose_processing_delay = 0.300
 
+        self.exposure_active_flag = False
+        self.uvled_pwm_cutoff_value = 0.25
+
         self.reactor = self.printer.get_reactor()
 
 
@@ -271,6 +274,7 @@ class PrinterFssProbe:
         if self.enable_powermgmt and self.resin_temp_setpoint != 0.0:
             self.resinheater.set_temp(self.resin_temp_setpoint)
 
+        self.exposure_active_flag = False
         self.last_gcmd.respond_raw("Z_move_comp")
 
     cmd_EXPOSE_help = "Sets the exposure power calibration value"
@@ -279,7 +283,12 @@ class PrinterFssProbe:
 
     cmd_EXPOSE_help = "Exposes a layer for a given time with a given PWM setting"
     def cmd_EXPOSE(self, gcmd):
-        self.last_exposure_power = gcmd.get_float("PWM", 0.1 , above=0.) * self.exposure_calibration
+
+        if self.exposure_active_flag:
+            logging.warning("Exposure already running, please try again later")
+            return
+
+        self.last_exposure_power = ((gcmd.get_float("PWM", 0.1 , above=0.) * self.exposure_calibration) * (1-self.uvled_pwm_cutoff_value))+self.uvled_pwm_cutoff_value
         self.last_exposure_time = gcmd.get_float("TIME", 1.0 , above=0.)
         self.last_exposure_pre_delay = gcmd.get_float("PRE_DELAY", 0 )
         self.last_exposure_post_delay = gcmd.get_float("POST_DELAY", 0 )
@@ -297,6 +306,7 @@ class PrinterFssProbe:
             if self.resin_temp_setpoint != 0.0:
                 self.resinheater.set_temp(0.0)
 
+        self.exposure_active_flag = True
         self.toolhead.register_lookahead_callback(self.exposure_timing_callback)
 
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -463,7 +463,7 @@ class PrinterFssProbe:
 
         first_stage_target_position = pos.copy()
 
-        first_stage_target_position[2] = first_stage_target_position - dip_first_stage
+        first_stage_target_position[2] = first_stage_target_position[2] - dip_first_stage
         self._move(first_stage_target_position,vmax)
 
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -5,6 +5,8 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
+import math
+from typing import Callable, Tuple
 import pins
 
 HINT_TIMEOUT = """
@@ -24,6 +26,8 @@ class PrinterFssProbe:
         self.min_lift_distance = config.getfloat('min_lift_distance', 2.0, above=.5)
         self.full_lift_speed = None
 
+        self.buildplate_area = 120*210 #make configurable in the future
+
         self.enable_powermgmt = config.getboolean("enable_uvled_powermgmt", True)
 
         if self.enable_powermgmt:
@@ -41,6 +45,7 @@ class PrinterFssProbe:
         self.last_exposure_pre_delay = 0
         self.last_exposure_post_delay = 0
         self.last_gcmd = None
+        self.last_resin_level = 5.0
 
         self.resin_temp_setpoint = 0.0
         self.resinheater = None
@@ -84,6 +89,9 @@ class PrinterFssProbe:
         self.gcode.register_command('ATHENA_PROBE_RESINLEVEL', self.cmd_ATHENA_PROBE_RESINLEVEL,
                                     desc=self.cmd_PROBE_help)
 
+        self.gcode.register_command('ATHENA_OVERRIDE_RESINLEVEL', self.cmd_ATHENA_OVERRIDE_RESINLEVEL,
+                                    desc=self.cmd_PROBE_help)
+
         self.gcode.register_command('ATHENA_MOVE', self.cmd_ATHENA_PROBE_DOWNWARDS,
                                     desc=self.cmd_PROBE_help)
 
@@ -103,6 +111,8 @@ class PrinterFssProbe:
         self.gcode.register_command('ATHENA_SET_MINIMUM_LIFT_DISTANCE', self.cmd_ATHENA_SET_MINIMUM_LIFT_DISTANCE)
 
         self.gcode.register_command('ATHENA_SET_FULL_LIFT_SPEED', self.cmd_ATHENA_SET_FULL_LIFT_SPEED)
+
+        self.gcode.register_command('ATHENA_SMART_DIP', self.cmd_ATHENA_SMART_DIP)
 
     def setup_pin(self, pin_type, pin_params):
         if pin_type != 'endstop' or pin_params['pin'] != 'z_virtual_endstop':
@@ -211,6 +221,168 @@ class PrinterFssProbe:
 
         return pos
 
+    def smart_peel(self, gcmd):
+        lift_amount = gcmd.get_float("Z", self.lift_amount, minval=0.)
+        lift_speed = gcmd.get_float("F", self.lift_speed, above=0.) / 60
+
+        pos = self._probe(lift_speed, lift_amount)
+
+        toolhead = self.printer.lookup_object('toolhead')
+
+        if self.peelmode == "minimal":
+            if pos[2] < self.min_lift_distance:
+                logging.info("Minimum lift distance not reached: %f required: %f", pos[2], self.min_lift_distance)
+                pos_actual = toolhead.get_position()
+                remaining_move = self.min_lift_distance - pos[2]
+
+                if remaining_move > 0.1:
+                    pos_actual[2] += remaining_move
+                    toolhead.manual_move(pos_actual, lift_speed)
+                    pos[2] = self.min_lift_distance
+                else:
+                    logging.info("Skipping due to hysteresis")
+
+        elif self.peelmode == "full":
+            logging.info("Peel finished after %f", pos[2])
+            pos_actual = toolhead.get_position()
+            remaining_move = lift_amount - pos[2]
+
+            if remaining_move > 0.1:
+
+                kin = toolhead.get_kinematics()
+                current_accel_decel = kin.get_accel_decel()
+                new_accel_decel = current_accel_decel.copy()
+                new_accel_decel["peel_accel"] = new_accel_decel["peel_decel"]
+                kin.set_accel_decel(new_accel_decel)
+
+                if pos[2] < self.min_lift_distance and self.min_lift_distance - pos[2] > 0.1:
+                    remaining_min_lift_move = self.min_lift_distance - pos[2]
+
+                    logging.info("Doing slow min lift first: %f mm",remaining_min_lift_move)
+
+                    pos_actual[2] += remaining_min_lift_move
+                    remaining_move -= remaining_min_lift_move
+                    toolhead.manual_move(pos_actual, lift_speed)
+
+
+                if self.full_lift_speed is None or self.full_lift_speed == 0 :
+                    speed = lift_speed*2
+                else:
+                    speed = self.full_lift_speed
+
+                pos_actual[2] += remaining_move
+                toolhead.manual_move(pos_actual, speed)
+
+                kin.set_accel_decel(current_accel_decel)
+                pos[2] = lift_amount
+            else:
+                logging.info("Skipping due to hysteresis")
+
+        return pos
+
+    def _calc_v1(self,r2,P,u,A):
+
+        top = 2 * math.pi * P * pow(r2,3)
+        bot = 3 + u + A
+
+        return top/bot
+
+    def _calc_v2(self,P,dl,u,A):
+        Cf = 0.0362 - ( 9.81 * pow(10,-8))
+
+        top = 2 * math.pi + pow( dl + Cf * P * A, 3)
+        bot = 3 * u * A
+
+        div = top / bot
+
+        v2 = P * div
+
+        return v2
+
+    def _calc_ttot(self,r2,v2,u,A,P,L):
+
+        t1 = r2/v2
+
+        t2top = (L-r2) * 3 * u * A
+        t2bot = 2 * math.pi * P * pow(r2,3)
+
+        ttot = t1 + (t2top/t2bot)
+
+        return ttot
+
+    def _optimize_r2(self,v2,u,A,P,L,tolerance=1e-8, max_iterations=1000):
+
+
+        invphi = (math.sqrt(5) - 1) / 2  # 1/phi
+        invphi2 = (3 - math.sqrt(5)) / 2  # 1/phi^2
+
+        a = 0
+        b = L
+
+        c = a + invphi2 * (b - a)
+        d = a + invphi * (b - a)
+        fc = self._calc_ttot(c,v2, u, A, P, L)
+        fd = self._calc_ttot(d,v2, u, A, P, L)
+
+        it = 0
+        while (b - a) > tolerance and it < max_iterations:
+            it += 1
+            if fc < fd:
+                b, d, fd = d, c, fc
+                c = a + invphi2 * (b - a)
+                fc = self._calc_ttot(c,v2, u, A, P, L)
+            else:
+                a, c, fc = c, d, fd
+                d = a + invphi * (b - a)
+                fd = self._calc_ttot(d,v2, u, A, P, L)
+
+        x = (a + b) / 2
+        logging.info(f"Completed Optimization after {it} iterations")
+        return x
+
+    def smart_dip(self, gcmd):
+
+        viscosity_cps = gcmd.get_float("VISCOSITY", above=0.) #from resin profile
+        resin_level_mm = self.last_resin_level
+        surface_area_mm2 = gcmd.get_float("SURFACEAREA", above=0.) #from print data
+        buildplate_area_mm2 = self.buildplate_area
+        layerheight_mm = gcmd.get_float("LAYERHEIGHT", above=0.) # from slice data
+        pressure_mpa = gcmd.get_float("PRESSURE", above=0.) #from resin profile
+        pressure_gfmm2 = pressure_mpa * .0000102
+        target_position = gcmd.get_float("TARGET", minval=0.)
+
+        toolhead = self.printer.lookup_object('toolhead')
+        pos = toolhead.get_position()
+        dip_amount = pos[2] - target_position
+
+        logging.info(f"Actual Dip Amount {dip_amount}, Target Z {target_position}")
+
+        if target_position < resin_level_mm:
+            build_area_factor = 1 / math.pow(math.e,target_position/3)
+            surface_area_mm2 += build_area_factor * buildplate_area_mm2
+            surface_area_mm2 = min(surface_area_mm2,buildplate_area_mm2)
+            logging.info(f"Offset surface area to {surface_area_mm2}, factor {build_area_factor}")
+
+        v2 = self._calc_v2(pressure_gfmm2,layerheight_mm,viscosity_cps,surface_area_mm2)
+        r2 = self._optimize_r2(v2,viscosity_cps,surface_area_mm2, pressure_gfmm2,dip_amount)
+        r1 = dip_amount - r2
+        v1 = self._calc_v1(r2,pressure_gfmm2,viscosity_cps,surface_area_mm2)
+
+        logging.info(f"Two-Stage Retract calculated: R1: {r1} | V1: {v1} | R2: {r2} | V2: {v2}")
+
+        pos1 = pos
+        pos1[2] -= r1
+
+        pos2 = pos1
+        pos2[2] -= r2
+
+        toolhead.manual_move(pos1, v1)
+        toolhead.manual_move(pos2, v2)
+
+        pos = toolhead.get_position()
+
+        return pos
+
     def run_probe_downwards(self, gcmd):
         dip_speed = gcmd.get_float("F", self.lift_speed, above=0.) / 60
         dip_amount = gcmd.get_float("Z", 0, minval=0.)
@@ -234,6 +406,10 @@ class PrinterFssProbe:
 
     cmd_PROBE_help = "Probe Z-height at current XY position"
 
+    def cmd_ATHENA_SMART_DIP(self,gcmd):
+        self.smart_dip(gcmd)
+        gcmd.respond_raw("Z_move_comp")
+
     def cmd_ATHENA_PROBE_UPWARDS(self, gcmd):
         pos = self.run_probe_upwards(gcmd)
         gcmd.respond_raw("Z_move_comp")
@@ -250,7 +426,11 @@ class PrinterFssProbe:
         pos = self.run_probe_downwards(gcmd)
         gcmd.respond_raw("Z_move_comp")
         gcmd.respond_raw("ResinLevel:%.2f" % (pos[2],))
+        self.last_resin_level = pos[2]
         self.last_z_result = pos[2]
+
+    def cmd_ATHENA_OVERRIDE_RESINLEVEL(self, gcmd):
+        self.last_resin_level = gcmd.get_float("LEVEL", above=0.)  # from resin profile
 
     def cmd_ATHENA_SET_PEELMODE_MINIMAL(self, gcmd):
         self.peelmode="minimal"

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -8,6 +8,7 @@ import logging
 import math
 from typing import Callable, Tuple
 import pins
+from webhooks import Sentinel
 
 HINT_TIMEOUT = """
 If the probe did not move far enough to trigger, then
@@ -113,6 +114,7 @@ class PrinterFssProbe:
         self.gcode.register_command('ATHENA_SET_FULL_LIFT_SPEED', self.cmd_ATHENA_SET_FULL_LIFT_SPEED)
 
         self.gcode.register_command('ATHENA_SMART_DIP', self.cmd_ATHENA_SMART_DIP)
+        self.gcode.register_command('ATHENA_SMART_PEEL', self.cmd_ATHENA_SMART_PEEL)
 
     def setup_pin(self, pin_type, pin_params):
         if pin_type != 'endstop' or pin_params['pin'] != 'z_virtual_endstop':
@@ -221,64 +223,61 @@ class PrinterFssProbe:
 
         return pos
 
-    def smart_peel(self, gcmd):
-        lift_amount = gcmd.get_float("Z", self.lift_amount, minval=0.)
-        lift_speed = gcmd.get_float("F", self.lift_speed, above=0.) / 60
+    def _calc_peel_v2(self,s2_minspeed, s2_maxarea, s2_maxspeed, s2_minarea,area):
+        coeff = (s2_maxspeed - s2_minspeed) / (s2_minarea - s2_maxarea)
+        speed = coeff * (area - s2_maxarea) + s2_minspeed
+        return max(min(speed,s2_maxspeed),s2_minspeed)
 
-        pos = self._probe(lift_speed, lift_amount)
+    def smart_peel(self, gcmd):
+        lift_total = gcmd.get_float("LIFT_TOTAL", Sentinel, minval=0.)
+        stage1_lift = gcmd.get_float("STAGE1_LIFT", Sentinel, minval=0.)
+        stage1_speed_mms = gcmd.get_float("STAGE1_SPEED", Sentinel, minval=0.) / 60
+        stage1_accel = gcmd.get_float("STAGE1_ACCEL", Sentinel, minval=0.)
+        interstage_accel = gcmd.get_float("INTERSTAGE_ACCEL", Sentinel, minval=0.)
+
+        stage2_minspeed = gcmd.get_float("STAGE2_MINSPEED", Sentinel, minval=0.)
+        stage2_maxarea = gcmd.get_float("STAGE2_MAXAREA", Sentinel, minval=0.)
+
+        stage2_maxspeed = gcmd.get_float("STAGE2_MAXSPEED", Sentinel, minval=0.)
+        stage2_minarea = gcmd.get_float("STAGE2_MINAREA", Sentinel, minval=0.)
+
+        surface_area_mm2 = gcmd.get_float("SURFACEAREA", above=0.) #from print data
+
+        stage2_speed_mms = self._calc_peel_v2(stage2_minspeed,stage2_maxarea,stage2_maxspeed,stage2_minarea,surface_area_mm2) / 60
 
         toolhead = self.printer.lookup_object('toolhead')
 
-        if self.peelmode == "minimal":
-            if pos[2] < self.min_lift_distance:
-                logging.info("Minimum lift distance not reached: %f required: %f", pos[2], self.min_lift_distance)
-                pos_actual = toolhead.get_position()
-                remaining_move = self.min_lift_distance - pos[2]
+        position = toolhead.get_position()
 
-                if remaining_move > 0.1:
-                    pos_actual[2] += remaining_move
-                    toolhead.manual_move(pos_actual, lift_speed)
-                    pos[2] = self.min_lift_distance
-                else:
-                    logging.info("Skipping due to hysteresis")
+        stage1_position = position
+        stage1_position[2] += stage1_lift
 
-        elif self.peelmode == "full":
-            logging.info("Peel finished after %f", pos[2])
-            pos_actual = toolhead.get_position()
-            remaining_move = lift_amount - pos[2]
+        stage2_position = position
+        stage2_position += lift_total
 
-            if remaining_move > 0.1:
+        kinematics = self.toolhead.get_kinematics()
 
-                kin = toolhead.get_kinematics()
-                current_accel_decel = kin.get_accel_decel()
-                new_accel_decel = current_accel_decel.copy()
-                new_accel_decel["peel_accel"] = new_accel_decel["peel_decel"]
-                kin.set_accel_decel(new_accel_decel)
+        saved_accel_decel = kinematics.get_accel_decel()
+        stage1_accel_decel = saved_accel_decel.copy()
+        stage1_accel_decel["peel_accel"] = stage1_accel
+        stage1_accel_decel["peel_decel"] = stage1_accel
 
-                if pos[2] < self.min_lift_distance and self.min_lift_distance - pos[2] > 0.1:
-                    remaining_min_lift_move = self.min_lift_distance - pos[2]
+        stage2_accel_decel = saved_accel_decel.copy()
+        stage2_accel_decel["peel_accel"] = interstage_accel
 
-                    logging.info("Doing slow min lift first: %f mm",remaining_min_lift_move)
+        kinematics.set_accel_decel(stage1_accel_decel)
 
-                    pos_actual[2] += remaining_min_lift_move
-                    remaining_move -= remaining_min_lift_move
-                    toolhead.manual_move(pos_actual, lift_speed)
+        toolhead.move(stage1_position,stage1_speed_mms)
 
+        kinematics.set_accel_decel(stage2_accel_decel)
 
-                if self.full_lift_speed is None or self.full_lift_speed == 0 :
-                    speed = lift_speed*2
-                else:
-                    speed = self.full_lift_speed
+        toolhead.move(stage2_position, stage2_speed_mms)
 
-                pos_actual[2] += remaining_move
-                toolhead.manual_move(pos_actual, speed)
+        kinematics.set_accel_decel(saved_accel_decel)
 
-                kin.set_accel_decel(current_accel_decel)
-                pos[2] = lift_amount
-            else:
-                logging.info("Skipping due to hysteresis")
+        toolhead.wait_moves()
 
-        return pos
+        return toolhead.get_position()
 
     def _calc_v1(self,r2,P,u,A):
 
@@ -409,6 +408,11 @@ class PrinterFssProbe:
     def cmd_ATHENA_SMART_DIP(self,gcmd):
         self.smart_dip(gcmd)
         gcmd.respond_raw("Z_move_comp")
+
+    def cmd_ATHENA_SMART_PEEL(self,gcmd):
+        self.smart_peel(gcmd)
+        gcmd.respond_raw("Z_move_comp")
+
 
     def cmd_ATHENA_PROBE_UPWARDS(self, gcmd):
         pos = self.run_probe_upwards(gcmd)

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -195,15 +195,17 @@ class PrinterFssProbe:
         saved_accel_decel = kinematics.get_accel_decel()
         stage1_accel_decel = saved_accel_decel.copy()
         stage1_accel_decel["peel_accel"] = .5
-        stage1_accel_decel["peel_decel"] = 1
+        stage1_accel_decel["peel_decel"] = 1000
         kinematics.set_accel_decel(stage1_accel_decel)
 
         self._move(stage1_position,lift_speed)
 
-        kinematics.set_accel_decel(saved_accel_decel)
+        stage1_accel_decel["peel_accel"] = 1000
+        kinematics.set_accel_decel(stage1_accel_decel)
 
         pos = self._probe(lift_speed, lift_amount-.5)
 
+        kinematics.set_accel_decel(saved_accel_decel)
 
         if self.peelmode == "minimal":
             if pos[2] < self.min_lift_distance:

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -58,6 +58,8 @@ class PrinterFssProbe:
         self.exposure_active_flag = False
         self.uvled_pwm_cutoff_value = 0.25
 
+        self.z_offset = 0.0
+
         self.reactor = self.printer.get_reactor()
 
 
@@ -105,6 +107,9 @@ class PrinterFssProbe:
         self.gcode.register_command('SET_EXPOSE_CALIBRATION', self.cmd_SET_EXPOSE_CALIBRATION,
                                     desc=self.cmd_SET_EXPOSE_CALIBRATION)
 
+        self.gcode.register_command('SET_Z_OFFSET', self.cmd_SET_Z_OFFSET,
+                                    desc=self.cmd_SET_Z_OFFSET_HELP)
+
         self.gcode.register_command('ATHENA_SET_PEELMODE_MINIMAL', self.cmd_ATHENA_SET_PEELMODE_MINIMAL)
 
         self.gcode.register_command('ATHENA_SET_PEELMODE_FULL', self.cmd_ATHENA_SET_PEELMODE_FULL)
@@ -128,6 +133,17 @@ class PrinterFssProbe:
             return gcmd.get_float("F", self.lift_speed, above=0.)
         return self.lift_speed
 
+    def _move(self, position, speed):
+        toolhead = self.printer.lookup_object('toolhead')
+        position[2] += self.z_offset
+        toolhead.move(position,speed)
+
+    def _get_position(self):
+        toolhead = self.printer.lookup_object('toolhead')
+        p = toolhead.get_position()
+        p[2] -= self.z_offset
+        return p
+
     def _probe(self, speed, amount):
         toolhead = self.printer.lookup_object('toolhead')
         curtime = self.printer.get_reactor().monotonic()
@@ -135,9 +151,9 @@ class PrinterFssProbe:
             raise self.printer.command_error("Must home before probe")
 
         phoming = self.printer.lookup_object('homing')
-        pos = toolhead.get_position()
+        pos = self._get_position()
         opos = pos[2]
-        pos[2] += amount
+        pos[2] += amount + self.z_offset
         epos = [pos[0], pos[1], pos[2]]
         try:
             epos = phoming.probing_move(self.mcu_probe, pos, speed)
@@ -151,12 +167,12 @@ class PrinterFssProbe:
 
             elif "No trigger on probe after full movement" in reason:
                 # in our case this is not an error but desired behaviorcr
-                epos = toolhead.get_position()
+                epos = self._get_position()
                 epos[2] = amount
 
             elif "Probe triggered prior to movement" in reason:
-                toolhead.move(pos, speed)
-                epos = toolhead.get_position()
+                self._move(pos, speed)
+                epos = self._get_position()
                 epos[2] = amount
 
             else:
@@ -175,19 +191,20 @@ class PrinterFssProbe:
         if self.peelmode == "minimal":
             if pos[2] < self.min_lift_distance:
                 logging.info("Minimum lift distance not reached: %f required: %f", pos[2], self.min_lift_distance)
-                pos_actual = toolhead.get_position()
+                pos_actual = self._get_position()
                 remaining_move = self.min_lift_distance - pos[2]
 
                 if remaining_move > 0.1:
                     pos_actual[2] += remaining_move
-                    toolhead.manual_move(pos_actual, lift_speed)
+                    self._move(pos_actual, lift_speed)
                     pos[2] = self.min_lift_distance
+                    toolhead.wait_moves()
                 else:
                     logging.info("Skipping due to hysteresis")
 
         elif self.peelmode == "full":
             logging.info("Peel finished after %f", pos[2])
-            pos_actual = toolhead.get_position()
+            pos_actual = self._get_position()
             remaining_move = lift_amount - pos[2]
 
             if remaining_move > 0.1:
@@ -205,7 +222,7 @@ class PrinterFssProbe:
 
                     pos_actual[2] += remaining_min_lift_move
                     remaining_move -= remaining_min_lift_move
-                    toolhead.manual_move(pos_actual, lift_speed)
+                    self._move(pos_actual, lift_speed)
 
 
                 if self.full_lift_speed is None or self.full_lift_speed == 0 :
@@ -214,10 +231,12 @@ class PrinterFssProbe:
                     speed = self.full_lift_speed
 
                 pos_actual[2] += remaining_move
-                toolhead.manual_move(pos_actual, speed)
+                self._move(pos_actual, speed)
 
                 kin.set_accel_decel(current_accel_decel)
                 pos[2] = lift_amount
+
+                toolhead.wait_moves()
             else:
                 logging.info("Skipping due to hysteresis")
 
@@ -234,8 +253,8 @@ class PrinterFssProbe:
         return max(min(speedv1,s1_maxspeed),s1_minspeed)
 
     def _calc_peel_l1(self,s1_minlift, s1_maxarea, s1_maxlift, s1_minarea,area):
-        coeff = (s1_maxlift - s1_minlift) / (s1_minarea - s1_maxarea)
-        lifts1 = coeff * (area - s1_maxarea) + s1_minlift
+        coeff = (s1_maxlift - s1_minlift) / (s1_maxarea - s1_minarea)
+        lifts1 = coeff * (area - s1_minarea) + s1_minlift
         return max(min(lifts1,s1_maxlift),s1_minlift)
 
     def smart_peel(self, gcmd):
@@ -268,12 +287,12 @@ class PrinterFssProbe:
 
         toolhead = self.printer.lookup_object('toolhead')
 
-        position = toolhead.get_position()
+        position = self._get_position()
 
         stage1_position = position.copy()
         stage1_position[2] += stage1_lift
 
-        stage2_position = stage1_position
+        stage2_position = position.copy()
         stage2_position[2] += lift_total
 
         kinematics = toolhead.get_kinematics()
@@ -288,87 +307,30 @@ class PrinterFssProbe:
 
         kinematics.set_accel_decel(stage1_accel_decel)
 
-        toolhead.move(stage1_position,stage1_speed)
+        self._move(stage1_position,stage1_speed)
 
         kinematics.set_accel_decel(stage2_accel_decel)
 
-        toolhead.move(stage2_position, stage2_speed)
+        self._move(stage2_position, stage2_speed)
 
         toolhead.wait_moves()
 
         kinematics.set_accel_decel(saved_accel_decel)
 
 
-        return toolhead.get_position()
-
-    def _calc_v1(self,r2,P,u,A,v1p1, v1p2):
-
-        top = v1p1 * 2 * math.pi * P * (v1p2*r2)**3
-        bot = 3 * u * A
-
-        return top/bot
-
-    def _calc_v2(self,P,P_gfmm2,dl,u,A,v2p1):
-
-        d_d =( (0.0362 * P_gfmm2 * A) - ( 9.81 * 10**-8 * (P_gfmm2*A)**2 )) / 1000
-
-        logging.info(f"Calc V2: d_d: {d_d} | P: {P} | dl: {dl} | u: {u} | A: {A}")
-
-        top = 2 * math.pi * ( dl + d_d)**3
-        bot = 3 * u * A
-
-        logging.info(f"Calc V2: Top: {top} | Bot: {bot}")
-
-        div = top / bot
-
-        v2 = P * div
-        v2 /= v2p1
-        logging.info(f"Calc V2: div: {div} | v2: {v2}")
-
-        return v2
-
-    def _calc_ttot(self,r2,v2,u,A,P,L,v1p1,v1p2):
-
-        t1 = r2/v2
-
-        t2top = (L-r2)
-        t2bot = self._calc_v1(r2,P,u,A,v1p1,v1p2)
-
-        ttot = t1 + (t2top/t2bot)
-
-        return ttot
-
-    def _optimize_r2(self,v2,u,A,P,L,v1p1,v1p2,tolerance=1e-8, max_iterations=1000):
+        return self._get_position()
 
 
-        invphi = (math.sqrt(5) - 1) / 2  # 1/phi
-        invphi2 = (3 - math.sqrt(5)) / 2  # 1/phi^2
 
-        a = 0
-        b = L
+    def _calc_v(self,P_mpa,dl,u,A,d_d):
+        v1 = ((P_mpa*math.pi*2*(d_d+dl)**3)/(3*u*A))*(600*(dl+d_d)/(math.sqrt(A/math.pi)))
+        v = min(max(v1,0.01),10)
+        return v
 
-        c = a + invphi2 * (b - a)
-        d = a + invphi * (b - a)
-        fc = self._calc_ttot(c,v2, u, A, P, L,v1p1,v1p2)
-        fd = self._calc_ttot(d,v2, u, A, P, L,v1p1,v1p2)
-
-        it = 0
-        while (b - a) > tolerance and it < max_iterations:
-            it += 1
-            if fc < fd:
-                b, d, fd = d, c, fc
-                c = a + invphi2 * (b - a)
-                fc = self._calc_ttot(c,v2, u, A, P, L,v1p1,v1p2)
-            else:
-                a, c, fc = c, d, fd
-                d = a + invphi * (b - a)
-                fd = self._calc_ttot(d,v2, u, A, P, L,v1p1,v1p2)
-
-        x = (a + b) / 2
-        logging.info(f"Completed Optimization after {it} iterations")
-        return x
 
     def smart_dip(self, gcmd):
+        #this version is an approximation of a constant pressure velocity profile using a similar scheme as a g2 command
+        logging.info(f"into smart_dip command")
         mPa_to_gfmm2 = .0000102
         viscosity_cps = gcmd.get_float("VISCOSITY", above=0.) #from resin profile
         resin_level_mm = self.last_resin_level
@@ -380,47 +342,51 @@ class PrinterFssProbe:
 
         target_position = gcmd.get_float("TARGET", minval=0.)
 
-        v1p1 = gcmd.get_float("V1P1", 8, minval=1)
-        v1p2 = gcmd.get_float("V1P2", 1.5, minval=1)
-        v2p1 = gcmd.get_float("V2P1", 2, minval=0)
-
-        vmin = gcmd.get_float("VMIN", 2, minval=0) / 60
+        # constant factors for generating velocity profile
+        resolution = 0.01 # similar to g2 gcode
+        vmin = 0.02 # minimum velocity 1.2mm/min
+        vmax = 10   # maximum velocity 600mm/min
+        max_force = 20000 #maximum force a retract move will try to achieve
+        viscosity_coefficient = 60   #constant for movements outside of squeezing flow regime
+        pressure_mpa_maxforce = (max_force/buildplate_area_mm2)/mPa_to_gfmm2    #pressure on build plate corresponding to maximum force
 
         toolhead = self.printer.lookup_object('toolhead')
-        pos = toolhead.get_position()
+        pos = self._get_position()
         dip_amount = pos[2] - target_position
-
+        d_d = max(0.1,(0.218*((surface_area_mm2*pressure_gfmm2)**0.821)) / 1000)    # maximum arm deflection from retract force on layer area
+        d_d2 = max(0.1,(0.218*((max_force)**0.821)) / 1000) # maximum arm deflection due to force on build plate
         logging.info(f"Actual Dip Amount {dip_amount}, Target Z {target_position}")
 
-        if target_position < (2 + 3*(viscosity_cps/10000)):
-        # if target_position < resin_level_mm:
-            build_area_factor = 1 / math.pow(math.e,target_position)
-            surface_area_mm2 += build_area_factor * buildplate_area_mm2
-            surface_area_mm2 = min(surface_area_mm2,buildplate_area_mm2)
-            logging.info(f"Offset surface area to {surface_area_mm2}, factor {build_area_factor}")
 
-        if (pressure_gfmm2*surface_area_mm2 > 20000):		# function to limit the maximum force the printer will try to achieve so it doesnt skip steps.
-            pressure_gfmm2 = 30000/surface_area_mm2
-            pressure_mpa = pressure_gfmm2/mPa_to_gfmm2
+        segments = max(1., math.floor(dip_amount / resolution))
+        if (target_position < resin_level_mm):
+            for i in range(1, int(segments) + 1):
+                step_pos = [0. , 0. , 0. , 0.]
+                step_pos[2] =  pos[2] - (i * resolution)
+                di = dip_amount + layerheight_mm - (i*resolution)
+                # velocity = minimum of velocity for maximum part pressure or velocity corresponding with maximum force
+                v1 = (6*(pressure_mpa*math.pi*2*(d_d+di)**3)/(3*viscosity_cps*surface_area_mm2))*(1 + (viscosity_coefficient*math.atan(((di)+d_d)/(math.sqrt(surface_area_mm2/math.pi)))))
+                v2 = (6*(pressure_mpa_maxforce*math.pi*2*(d_d2+di)**3)/(3*viscosity_cps*buildplate_area_mm2))*(1 + (viscosity_coefficient*math.atan(((di)+d_d2)/(math.sqrt(buildplate_area_mm2/math.pi)))))
+                v3 = min(v1,v2)
+                velocity = min(max(v3,vmin),vmax)
+                self._move(step_pos,velocity)
 
-        v2 = max(vmin,self._calc_v2(pressure_mpa,pressure_gfmm2,layerheight_mm,viscosity_cps,surface_area_mm2,v2p1))
-        r2 = self._optimize_r2(v2,viscosity_cps,surface_area_mm2, pressure_mpa,dip_amount,v1p1,v1p2)
-        r1 = dip_amount - r2
-        v1 = max(vmin,self._calc_v1(r2,pressure_mpa,viscosity_cps,surface_area_mm2,v1p1,v1p2))
-
-        logging.info(f"Two-Stage Retract calculated: R1: {r1} | V1: {v1} | R2: {r2} | V2: {v2}")
-        gcmd.respond_raw(f"Smart Retract Computed Values - S1 Distance: {r1}mm | S1 Speed: {v1*60}mm/min | S2 Distance: {r2}mm | S2 Lift Speed: {v2*60}mm/min")
-
-        pos1 = pos
-        pos1[2] -= r1
-
-        pos2 = pos1
-        pos2[2] -= r2
-
-        toolhead.move(pos1, v1)
-        toolhead.move(pos2, v2)
+        else:
+            for i in range(1, int(segments) + 1):
+                step_pos = [0. , 0. , 0. , 0.]
+                step_pos[2] =  pos[2] - (i * resolution)
+                di = dip_amount + layerheight_mm - (i*resolution)
+                v1 = (6*(pressure_mpa*math.pi*2*(d_d+(di))**3)/(3*viscosity_cps*surface_area_mm2))*(1 + (viscosity_coefficient*math.atan(((di)+d_d)/(math.sqrt(surface_area_mm2/math.pi)))))
+                velocity = min(max(v1,vmin),vmax)
+                self._move(step_pos,velocity)
         toolhead.wait_moves()
-        pos = toolhead.get_position()
+        pos = self._get_position()
+
+        # function that removes any error on final position due to segmentation resolution
+        if (pos[2] != target_position):
+            self._move([0,0,target_position,0],velocity)
+            toolhead.wait_moves()
+            pos = self._get_position()
 
         return pos
 
@@ -429,7 +395,7 @@ class PrinterFssProbe:
         dip_amount = gcmd.get_float("Z", 0, minval=0.)
         move_absolute = gcmd.get_int("ABS",0, minval=0, maxval=1)
         toolhead = self.printer.lookup_object('toolhead')
-        pos = toolhead.get_position()
+        pos = self._get_position()
 
         if move_absolute == 1:
             dip_amount = (pos[2] - dip_amount) *-1
@@ -441,7 +407,7 @@ class PrinterFssProbe:
 
         pos = self._probe(dip_speed, dip_amount)  # probe to zero
 
-        pos = toolhead.get_position()
+        pos = self._get_position()
 
         return pos
 
@@ -474,6 +440,10 @@ class PrinterFssProbe:
         gcmd.respond_raw("ResinLevel:%.2f" % (pos[2],))
         self.last_resin_level = pos[2]
         self.last_z_result = pos[2]
+
+    def cmd_ATHENA_OVERRIDE_RESINLEVEL(self, gcmd):
+        self.last_resin_level = gcmd.get_float("LEVEL", above=0.)  # from resin profile
+
 
     def cmd_ATHENA_OVERRIDE_RESINLEVEL(self, gcmd):
         self.last_resin_level = gcmd.get_float("LEVEL", above=0.)  # from resin profile
@@ -519,6 +489,10 @@ class PrinterFssProbe:
     cmd_EXPOSE_help = "Sets the exposure power calibration value"
     def cmd_SET_EXPOSE_CALIBRATION(self,gcmd):
         self.exposure_calibration = gcmd.get_float("VALUE", 1 , above=0.)
+
+    cmd_SET_Z_OFFSET_help = "Sets the z-offset for probing and smart moves"
+    def cmd_SET_Z_OFFSET(self,gcmd):
+        self.z_offset = gcmd.get_float("OFFSET", 0 , minval=0. )
 
     cmd_EXPOSE_help = "Exposes a layer for a given time with a given PWM setting"
     def cmd_EXPOSE(self, gcmd):

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -186,8 +186,8 @@ class PrinterFssProbe:
                 new_accel_decel["peel_accel"] = new_accel_decel["peel_decel"]
                 kin.set_accel_decel(new_accel_decel)
 
-                if pos[2] < self.min_lift_distance and pos[2] - self.min_lift_distance > 0.1:
-                    remaining_min_lift_move = pos[2] - self.min_lift_distance
+                if pos[2] < self.min_lift_distance and self.min_lift_distance - pos[2] > 0.1:
+                    remaining_min_lift_move = self.min_lift_distance - pos[2]
 
                     logging.info("Doing slow min lift first: %f mm",remaining_min_lift_move)
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -447,10 +447,6 @@ class PrinterFssProbe:
     def cmd_ATHENA_OVERRIDE_RESINLEVEL(self, gcmd):
         self.last_resin_level = gcmd.get_float("LEVEL", above=0.)  # from resin profile
 
-
-    def cmd_ATHENA_OVERRIDE_RESINLEVEL(self, gcmd):
-        self.last_resin_level = gcmd.get_float("LEVEL", above=0.)  # from resin profile
-
     def cmd_ATHENA_SET_PEELMODE_MINIMAL(self, gcmd):
         self.peelmode="minimal"
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -25,6 +25,7 @@ class PrinterFssProbe:
         self.lift_speed = config.getfloat('lift_speed', 10.0, above=0.)
         self.lift_amount = config.getfloat('lift_amount', 10.0, above=0.)
         self.min_lift_distance = config.getfloat('min_lift_distance', 2.0, above=.5)
+        self.smart_dip_segment_resolution = config.getfloat("smart_dip_segment_resolution", 0.005, above=0.)
         self.full_lift_speed = None
 
         self.buildplate_area = 120*210 #make configurable in the future
@@ -183,12 +184,13 @@ class PrinterFssProbe:
     def run_probe_upwards(self, gcmd):
         lift_amount = gcmd.get_float("Z", self.lift_amount, minval=0.)
         lift_speed = gcmd.get_float("F", self.lift_speed, above=0.) / 60
+        stage1_lift_distance = 0.5
         toolhead = self.printer.lookup_object('toolhead')
 
         position = self._get_position()
 
         stage1_position = position.copy()
-        stage1_position[2] += 0.5
+        stage1_position[2] += stage1_lift_distance
 
         kinematics = toolhead.get_kinematics()
 
@@ -203,7 +205,7 @@ class PrinterFssProbe:
         stage1_accel_decel["peel_accel"] = 1000
         kinematics.set_accel_decel(stage1_accel_decel)
 
-        pos = self._probe(lift_speed, lift_amount-.5)
+        pos = self._probe(lift_speed, lift_amount - stage1_lift_distance)
 
         kinematics.set_accel_decel(saved_accel_decel)
 
@@ -224,7 +226,8 @@ class PrinterFssProbe:
         elif self.peelmode == "full":
             logging.info("Peel finished after %f", pos[2])
             pos_actual = self._get_position()
-            remaining_move = lift_amount - pos[2]
+            already_travelled = stage1_lift_distance + pos[2]
+            remaining_move = lift_amount - already_travelled
 
             if remaining_move > 0.1:
 
@@ -234,8 +237,8 @@ class PrinterFssProbe:
                 new_accel_decel["peel_accel"] = new_accel_decel["peel_decel"]
                 kin.set_accel_decel(new_accel_decel)
 
-                if pos[2] < self.min_lift_distance and self.min_lift_distance - pos[2] > 0.1:
-                    remaining_min_lift_move = self.min_lift_distance - pos[2]
+                if self.min_lift_distance - already_travelled > 0.1:
+                    remaining_min_lift_move = self.min_lift_distance - already_travelled
 
                     logging.info("Doing slow min lift first: %f mm",remaining_min_lift_move)
 
@@ -366,7 +369,7 @@ class PrinterFssProbe:
             surface_area_mm2 = 210*120*0.2
 
         # constant factors for generating velocity profile
-        resolution = 0.005 # similar to g2 gcode
+        resolution = self.smart_dip_segment_resolution # similar to g2 gcode
         vmin = 0.05 # minimum velocity 0.3mm/min
         vmax = target_speed / 60   # maximum velocity 600mm/min
         max_force = 20000 #maximum force a retract move will try to achieve

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -294,10 +294,13 @@ class PrinterFssProbe:
         lift_total = gcmd.get_float("LIFT_TOTAL", above=0.)
         lift_speed = gcmd.get_float("SPEED", self.lift_speed, above=0.)
 
-        total_surface_area_mm2 = gcmd.get_float("TOTAL_SURFACEAREA", above=0.) #from print data
-        largest_surface_area_mm2 = gcmd.get_float("LARGEST_SURFACEAREA", above=0.) #from print data
+        total_surface_area_mm2 = gcmd.get_float("TOTAL_SURFACEAREA", minval=0.) #from print data
+        largest_surface_area_mm2 = gcmd.get_float("LARGEST_SURFACEAREA", minval=0.) #from print data
         modulus_gpa = gcmd.get_float("MODULUS", above=0.) #from resin profile
         viscosity_cps = gcmd.get_float("VISCOSITY", above=0.) #from resin profile
+
+        if largest_surface_area_mm2 == 0.0:
+            largest_surface_area_mm2 = self.buildplate_area * 0.2
 
         stage1_max_speed = lift_speed / 2
         stage1_min_speed = lift_speed / 4
@@ -330,7 +333,7 @@ class PrinterFssProbe:
             stage1_distance = max(stage1_distance, round(actual_lift_distance/2, 2))
 
         else:
-            areaRatio = largest_surface_area_mm2 / total_surface_area_mm2
+            areaRatio = largest_surface_area_mm2 / self.buildplate_area
             areaFactor = pow(areaRatio, 1 / 4)
             minSpeed = max(stage1_max_speed, lift_speed * (1 - 1/2 * modulus_gpa))
             stage2_distance = round((1 + stage2_distance * areaFactor),1)

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -341,7 +341,9 @@ class PrinterFssProbe:
 
 
         stage1Speed = max(stage1_min_speed, round(speed * 0.15 * (1 / modulus_gpa),2))
+        stage1Speed = min(stage1_max_speed,stage1Speed)
         stage2Speed = max(stage2_min_speed, speed)
+        stage2Speed = min(stage2_max_speed, stage2Speed)
 
         actual_lift_distance = stage1_distance + stage2_distance # recompute due to likely changes in previous code
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -463,7 +463,7 @@ class PrinterFssProbe:
 
         first_stage_target_position = pos.copy()
 
-        first_stage_target_position[2] = first_stage_target_position[2] - dip_first_stage
+        first_stage_target_position[2] -=  dip_first_stage
         self._move(first_stage_target_position,vmax)
 
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -326,7 +326,7 @@ class PrinterFssProbe:
         logging.warning(f"Smart Peel first calc run: S1D: {stage1_distance} | S2D: {stage2_distance}")
 
         if layer_position < effective_resin_level:
-            speed = max(stage2_max_speed, round(lift_speed/2 , 1))
+            speed = lift_speed/2
             stage1_distance = max(stage1_distance, round(actual_lift_distance/2, 2))
 
         else:

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -524,7 +524,8 @@ class PrinterFssProbe:
         if self.kinematic_mode != "smart":
             target_position = gcmd.get_float("TARGET", minval=0.)
             target_speed = gcmd.get_float("SPEED", minval=0.) / 60.0
-            pos = [0,0,target_position]
+            pos = self._get_position()
+            pos[2] = target_position
             self._move(pos,target_speed)
             self.toolhead.wait_moves()
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -326,7 +326,7 @@ class PrinterFssProbe:
         pos = self._get_position()
         layer_position = pos[2]
 
-        stage1_distance = min(lift_total - 1, max(1, round(lift_total / pow(3 * modulus_gpa, 2 / 3), 1)))
+        stage1_distance = min(2.5, max(1, round(lift_total / pow(3 * modulus_gpa, 2 / 3), 1)))
         stage2_distance = lift_total - stage1_distance
 
         logging.warning(f"Smart Peel first calc run: S1D: {stage1_distance} | S2D: {stage2_distance}")
@@ -339,7 +339,7 @@ class PrinterFssProbe:
             areaRatio = largest_surface_area_mm2 / self.buildplate_area
             areaFactor = pow(areaRatio, 1 / 4)
             minSpeed = max(stage1_max_speed, lift_speed * (modulus_gpa / 6 + 1/2))
-            stage2_distance = round((1 + stage2_distance * areaFactor),1)
+            stage2_distance = round((2 + stage2_distance * areaFactor),1)
             speed = round((minSpeed + (lift_speed - minSpeed) * (1-areaFactor)) , 2)
 
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -423,9 +423,9 @@ class PrinterFssProbe:
         toolhead.wait_moves()
 
         kinematics.set_accel_decel(saved_accel_decel)
-        logging.warning(f"Smart Peel - Commanded Lift: {lift_total} | Stage 1 Lift: {stage1_distance} | Stage 1 Speed: {stage1Speed} | Stage 2 Lift: {stage2_distance} | Stage 2 Speed: {stage2Speed}")
+        #logging.warning(f"Smart Peel - Commanded Lift: {lift_total} | Stage 1 Lift: {stage1_distance} | Stage 1 Speed: {stage1Speed} | Stage 2 Lift: {stage2_distance} | Stage 2 Speed: {stage2Speed}")
 
-        logstr = f"Smart Peel Move Stats - CL:{lift_total} | AL:{actual_lift_distance} | S1L:{stage1_distance} | S2L:{stage2_distance} | S1S:{stage1Speed*60.0} | S2S:{stage2Speed*60.0} | PDT:{pd_trigger_position} | Peel Detection: "
+        logstr = f"Smart Peel Move Stats - LP:{layer_position} | CL:{lift_total} | AL:{actual_lift_distance} | S1L:{stage1_distance} | S2L:{stage2_distance} | S1S:{stage1Speed*60.0} | S2S:{stage2Speed*60.0} | PDT:{pd_trigger_position} | Peel Detection: "
         if pd_trigger_position == 0.0:
             logstr += "Disabled"
         elif pd_trigger_position == stage1_distance:
@@ -485,7 +485,7 @@ class PrinterFssProbe:
 
         d_d = max(0.1,(0.218*((surface_area_mm2*pressure_gfmm2)**0.821)) / 1000)    # maximum arm deflection from retract force on layer area
         d_d2 = max(0.1, (0.218 * (max_force ** 0.821)) / 1000) # maximum arm deflection due to force on build plate
-        logging.info(f"Actual Dip Amount {dip_amount}, Target Z {target_position}, First Stage Amound: {dip_first_stage}, First Stage Target: {first_stage_target_position[2]}, Second Stage: {dip_second_stage}")
+        logging.info(f"Smart Dip Move Stats - DA:{dip_amount} | TZ:{target_position} | S1D:{dip_first_stage} | S1T:{first_stage_target_position[2]} | S2D:{dip_second_stage}")
 
         segments = max(1., math.floor(dip_second_stage / resolution))
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -229,17 +229,17 @@ class PrinterFssProbe:
         return max(min(speed,s2_maxspeed),s2_minspeed)
 
     def smart_peel(self, gcmd):
-        lift_total = gcmd.get_float("LIFT_TOTAL", Sentinel, minval=0.)
-        stage1_lift = gcmd.get_float("STAGE1_LIFT", Sentinel, minval=0.)
-        stage1_speed_mms = gcmd.get_float("STAGE1_SPEED", Sentinel, minval=0.) / 60
-        stage1_accel = gcmd.get_float("STAGE1_ACCEL", Sentinel, minval=0.)
-        interstage_accel = gcmd.get_float("INTERSTAGE_ACCEL", Sentinel, minval=0.)
+        lift_total = gcmd.get_float("LIFT_TOTAL",  minval=0.)
+        stage1_lift = gcmd.get_float("STAGE1_LIFT",  minval=0.)
+        stage1_speed_mms = gcmd.get_float("STAGE1_SPEED",  minval=0.) / 60
+        stage1_accel = gcmd.get_float("STAGE1_ACCEL",  minval=0.)
+        interstage_accel = gcmd.get_float("INTERSTAGE_ACCEL",  minval=0.)
 
-        stage2_minspeed = gcmd.get_float("STAGE2_MINSPEED", Sentinel, minval=0.)
-        stage2_maxarea = gcmd.get_float("STAGE2_MAXAREA", Sentinel, minval=0.)
+        stage2_minspeed = gcmd.get_float("STAGE2_MINSPEED",  minval=0.)
+        stage2_maxarea = gcmd.get_float("STAGE2_MAXAREA",  minval=0.)
 
-        stage2_maxspeed = gcmd.get_float("STAGE2_MAXSPEED", Sentinel, minval=0.)
-        stage2_minarea = gcmd.get_float("STAGE2_MINAREA", Sentinel, minval=0.)
+        stage2_maxspeed = gcmd.get_float("STAGE2_MAXSPEED",  minval=0.)
+        stage2_minarea = gcmd.get_float("STAGE2_MINAREA",  minval=0.)
 
         surface_area_mm2 = gcmd.get_float("SURFACEAREA", above=0.) #from print data
 
@@ -280,15 +280,18 @@ class PrinterFssProbe:
 
         return toolhead.get_position()
 
-    def _calc_v1(self,r2,P,u,A):
+    def _calc_v1(self,r2,P,u,A,v1p1, v1p2):
 
-        top = 2 * math.pi * P * r2**3
+        top = v1p1 * 2 * math.pi * P * (v1p2*r2)**3
         bot = 3 * u * A
 
         return top/bot
 
-    def _calc_v2(self,P,dl,u,A):
-        d_d =( (0.0362 * P * A) - ( 9.81 * 10**-8 * (P*A)**2 )) / 1000
+    def _calc_v2(self,P,dl,u,A,v2p1):
+        mPa_to_gfmm2 = .0000102
+        P_gfmm2 = P * mPa_to_gfmm2
+
+        d_d =( (0.0362 * P_gfmm2 * A) - ( 9.81 * 10**-8 * (P_gfmm2*A)**2 )) / 1000
 
         logging.info(f"Calc V2: d_d: {d_d} | P: {P} | dl: {dl} | u: {u} | A: {A}")
 
@@ -300,7 +303,7 @@ class PrinterFssProbe:
         div = top / bot
 
         v2 = P * div
-
+        v2 /= v2p1
         logging.info(f"Calc V2: div: {div} | v2: {v2}")
 
         return v2
@@ -347,17 +350,20 @@ class PrinterFssProbe:
         return x
 
     def smart_dip(self, gcmd):
-        mPa_to_gfmm2 = .0000102
 
         viscosity_cps = gcmd.get_float("VISCOSITY", above=0.) #from resin profile
-        viscosity_gfmm2s = viscosity_cps * mPa_to_gfmm2
         resin_level_mm = self.last_resin_level
         surface_area_mm2 = gcmd.get_float("SURFACEAREA", above=0.) #from print data
         buildplate_area_mm2 = self.buildplate_area
         layerheight_mm = gcmd.get_float("LAYERHEIGHT", above=0.) # from slice data
         pressure_mpa = gcmd.get_float("PRESSURE", above=0.) #from resin profile
-        pressure_gfmm2 = pressure_mpa * mPa_to_gfmm2
         target_position = gcmd.get_float("TARGET", minval=0.)
+
+        v1p1 = gcmd.get_float("V1P1", 8, minval=1)
+        v1p2 = gcmd.get_float("V1P2", 1.5, minval=1)
+        v2p1 = gcmd.get_float("V2P1", 2, minval=0)
+
+        vmin = gcmd.get_float("VMIN", 2, minval=0)
 
         toolhead = self.printer.lookup_object('toolhead')
         pos = toolhead.get_position()
@@ -365,16 +371,17 @@ class PrinterFssProbe:
 
         logging.info(f"Actual Dip Amount {dip_amount}, Target Z {target_position}")
 
-        if target_position < resin_level_mm:
-            build_area_factor = 1 / math.pow(math.e,target_position/3)
+        if target_position < (2 + 3*(viscosity_cps/10000)):
+        # if target_position < resin_level_mm:
+            build_area_factor = 1 / math.pow(math.e,target_position)
             surface_area_mm2 += build_area_factor * buildplate_area_mm2
             surface_area_mm2 = min(surface_area_mm2,buildplate_area_mm2)
             logging.info(f"Offset surface area to {surface_area_mm2}, factor {build_area_factor}")
 
-        v2 = self._calc_v2(pressure_gfmm2,layerheight_mm,viscosity_gfmm2s,surface_area_mm2)
-        r2 = self._optimize_r2(v2,viscosity_gfmm2s,surface_area_mm2, pressure_gfmm2,dip_amount)
+        v2 = max(vmin,self._calc_v2(pressure_mpa,layerheight_mm,viscosity_cps,surface_area_mm2,v2p1))
+        r2 = self._optimize_r2(v2,viscosity_cps,surface_area_mm2, pressure_mpa,dip_amount)
         r1 = dip_amount - r2
-        v1 = self._calc_v1(r2,pressure_gfmm2,viscosity_gfmm2s,surface_area_mm2)
+        v1 = max(vmin,self._calc_v1(r2,pressure_mpa,viscosity_cps,surface_area_mm2,v1p1,v1p2))
 
         logging.info(f"Two-Stage Retract calculated: R1: {r1} | V1: {v1} | R2: {r2} | V2: {v2}")
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -108,7 +108,7 @@ class PrinterFssProbe:
                                     desc=self.cmd_SET_EXPOSE_CALIBRATION)
 
         self.gcode.register_command('SET_Z_OFFSET', self.cmd_SET_Z_OFFSET,
-                                    desc=self.cmd_SET_Z_OFFSET_HELP)
+                                    desc=self.cmd_SET_Z_OFFSET_help)
 
         self.gcode.register_command('ATHENA_SET_PEELMODE_MINIMAL', self.cmd_ATHENA_SET_PEELMODE_MINIMAL)
 
@@ -489,7 +489,6 @@ class PrinterFssProbe:
         self.exposure_active_flag = False
         self.last_gcmd.respond_raw("Z_move_comp")
 
-    cmd_EXPOSE_help = "Sets the exposure power calibration value"
     def cmd_SET_EXPOSE_CALIBRATION(self,gcmd):
         self.exposure_calibration = gcmd.get_float("VALUE", 1 , above=0.)
 
@@ -497,7 +496,7 @@ class PrinterFssProbe:
     def cmd_SET_Z_OFFSET(self,gcmd):
         self.z_offset = gcmd.get_float("OFFSET", 0 , minval=0. )
 
-    cmd_SET_Z_OFFSET_help = "Exposes a layer for a given time with a given PWM setting"
+    cmd_EXPOSE_help = "Exposes a layer for a given time with a given PWM setting"
     def cmd_EXPOSE(self, gcmd):
 
         if self.exposure_active_flag:

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -353,7 +353,7 @@ class PrinterFssProbe:
         mPa_to_gfmm2 = .0000102
         viscosity_cps = gcmd.get_float("VISCOSITY", above=0.) #from resin profile
         resin_level_mm = self.last_resin_level
-        surface_area_mm2 = gcmd.get_float("SURFACEAREA", above=0.) #from print data
+        surface_area_mm2 = gcmd.get_float("SURFACEAREA", minval=0.) #from print data
         buildplate_area_mm2 = self.buildplate_area
         layerheight_mm = gcmd.get_float("LAYERHEIGHT", above=0.) # from slice data
         pressure_mpa = gcmd.get_float("PRESSURE", above=0.) #from resin profile
@@ -361,6 +361,9 @@ class PrinterFssProbe:
 
         target_position = gcmd.get_float("TARGET", minval=0.)
         target_speed = gcmd.get_float("SPEED", minval=0.)
+
+        if surface_area_mm2 > 40000 or surface_area_mm2 == 0:
+            surface_area_mm2 = 210*120*0.2
 
         # constant factors for generating velocity profile
         resolution = 0.005 # similar to g2 gcode

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -335,12 +335,15 @@ class PrinterFssProbe:
         else:
             areaRatio = largest_surface_area_mm2 / self.buildplate_area
             areaFactor = pow(areaRatio, 1 / 4)
-            minSpeed = max(stage1_max_speed, lift_speed * (1 - 1/2 * modulus_gpa))
+            #minSpeed = max(stage1_max_speed, lift_speed * (1 - 1/2 * modulus_gpa)) #matteos version
+            minSpeed = max(stage1_max_speed, lift_speed * (modulus_gpa / 6 + 1 / 2))#jacobis version
             stage2_distance = round((1 + stage2_distance * areaFactor),1)
             speed = round((minSpeed + (lift_speed - minSpeed) * (1-areaFactor)) , 2)
 
 
-        stage1Speed = max(stage1_min_speed, round(speed * 0.15 * (1 / modulus_gpa),2))
+        #stage1Speed = max(stage1_min_speed, round(speed * 0.15 * (1 / modulus_gpa),2)) #matteos version
+        stage1Speed = max(stage1_min_speed, round(speed ** 2 / lift_speed * modulus_gpa, 2)) #jacobis version
+
         stage1Speed = min(stage1_max_speed,stage1Speed)
         stage2Speed = max(stage2_min_speed, speed)
         stage2Speed = min(stage2_max_speed, stage2Speed)

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -179,11 +179,6 @@ class PrinterFssProbe:
             remaining_move = lift_amount - pos[2]
 
             if remaining_move > 0.1:
-                pos_actual[2] += remaining_move
-                if self.full_lift_speed is None or self.full_lift_speed == 0 :
-                    speed = lift_speed*2
-                else:
-                    speed = self.full_lift_speed
 
                 kin = toolhead.get_kinematics()
                 current_accel_decel = kin.get_accel_decel()
@@ -191,6 +186,22 @@ class PrinterFssProbe:
                 new_accel_decel["peel_accel"] = new_accel_decel["peel_decel"]
                 kin.set_accel_decel(new_accel_decel)
 
+                if pos[2] < self.min_lift_distance and pos[2] - self.min_lift_distance > 0.1:
+                    remaining_min_lift_move = pos[2] - self.min_lift_distance
+
+                    logging.info("Doing slow min lift first: %f mm",remaining_min_lift_move)
+
+                    pos_actual[2] += remaining_min_lift_move
+                    remaining_move -= remaining_min_lift_move
+                    toolhead.manual_move(pos_actual, lift_speed)
+
+
+                if self.full_lift_speed is None or self.full_lift_speed == 0 :
+                    speed = lift_speed*2
+                else:
+                    speed = self.full_lift_speed
+
+                pos_actual[2] += remaining_move
                 toolhead.manual_move(pos_actual, speed)
 
                 kin.set_accel_decel(current_accel_decel)
@@ -249,7 +260,7 @@ class PrinterFssProbe:
         self.min_lift_distance = gcmd.get_float("VALUE", self.lift_amount, minval=0.)
 
     def cmd_ATHENA_SET_FULL_LIFT_SPEED(self, gcmd):
-        self.full_lift_speed = gcmd.get_float("VALUE", self.lift_speed, minval=0.)
+        self.full_lift_speed = gcmd.get_float("VALUE", self.lift_speed * 60, minval=0.) / 60
 
 
     cmd_QUERY_FSS_help = "Return the status of the z-probe"

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -61,6 +61,14 @@ class PrinterFssProbe:
 
         self.z_offset = 0.0
 
+        self.x_res = 15120
+        self.y_res = 6230
+        self.x_px = 19
+        self.y_px = 14
+        self.total_screen_area = (self.x_res * self.x_px) * (self.y_res * self.y_px)
+
+
+
         self.reactor = self.printer.get_reactor()
 
 
@@ -185,6 +193,10 @@ class PrinterFssProbe:
         lift_amount = gcmd.get_float("Z", self.lift_amount, minval=0.)
         lift_speed = gcmd.get_float("F", self.lift_speed, above=0.) / 60
         stage1_lift_distance = 0.2
+        lift_segment_distance = 0.2
+        target_accel = 1000.
+        base_accel = 0.1
+
         toolhead = self.printer.lookup_object('toolhead')
 
         position = self._get_position()
@@ -196,16 +208,30 @@ class PrinterFssProbe:
 
         saved_accel_decel = kinematics.get_accel_decel()
         stage1_accel_decel = saved_accel_decel.copy()
-        stage1_accel_decel["peel_accel"] = .1
-        stage1_accel_decel["peel_decel"] = 1000
+        stage1_accel_decel["peel_accel"] = base_accel
+        stage1_accel_decel["peel_decel"] = target_accel
         kinematics.set_accel_decel(stage1_accel_decel)
 
-        self._move(stage1_position,lift_speed)
+
+        segments = int(self.min_lift_distance / lift_segment_distance)
+        for i in range(1,segments):
+            pos = position.copy()
+            pos[2] += i*lift_segment_distance
+            acc = saved_accel_decel.copy()
+            acc["peel_accel"] = min(target_accel,base_accel*2**i)
+            kinematics.set_accel_decel(acc)
+            self._move(pos,lift_speed)
+
 
         stage1_accel_decel["peel_accel"] = 1000
         kinematics.set_accel_decel(stage1_accel_decel)
 
-        pos = self._probe(lift_speed, lift_amount - stage1_lift_distance)
+        print_time = toolhead.get_last_move_time()
+
+        if not self.mcu_probe.query_endstop(print_time):
+            pos = self._probe(lift_speed, lift_amount - stage1_lift_distance)
+        else:
+            pos = [0.0,0.0,self.min_lift_distance]
 
         kinematics.set_accel_decel(saved_accel_decel)
 
@@ -264,109 +290,114 @@ class PrinterFssProbe:
 
         return pos
 
-    def _calc_peel_v2(self,s2_minspeed, s2_maxarea, s2_maxspeed, s2_minarea,area):
-        coeff = (s2_maxspeed - s2_minspeed) / (s2_minarea - s2_maxarea)
-        speed = coeff * (area - s2_maxarea) + s2_minspeed
-        return max(min(speed,s2_maxspeed),s2_minspeed)
-
-    def _calc_peel_v1(self,s1_minspeed, s1_maxarea, s1_maxspeed, s1_minarea,area):
-        coeff = (s1_maxspeed - s1_minspeed) / (s1_minarea - s1_maxarea)
-        speedv1 = coeff * (area - s1_maxarea) + s1_minspeed
-        return max(min(speedv1,s1_maxspeed),s1_minspeed)
-
-    def _calc_peel_l1(self,s1_minlift, s1_maxarea, s1_maxlift, s1_minarea,area):
-        coeff = (s1_maxlift - s1_minlift) / (s1_maxarea - s1_minarea)
-        lifts1 = coeff * (area - s1_minarea) + s1_minlift
-        return max(min(lifts1,s1_maxlift),s1_minlift)
-
     def smart_peel(self, gcmd):
         lift_total = gcmd.get_float("LIFT_TOTAL", above=0.)
-        stage1_minlift = gcmd.get_float("STAGE1_MINLIFT", above=0.)
-        stage1_maxlift = gcmd.get_float("STAGE1_MAXLIFT", above=0.)
-        stage1_minspeed = gcmd.get_float("STAGE1_MINSPEED", above=0.) / 60
-        stage1_maxspeed = gcmd.get_float("STAGE1_MAXSPEED", above=0.) / 60
-        stage1_accel = gcmd.get_float("STAGE1_ACCEL", above=0.)
-        interstage_accel = gcmd.get_float("INTERSTAGE_ACCEL", above=0.)
+        lift_speed = gcmd.get_float("SPEED", self.lift_speed, above=0.) / 60
 
-        stage1_maxarea = gcmd.get_float("STAGE1_MAXAREA", above=0.)
-        stage1_minarea = gcmd.get_float("STAGE1_MINAREA", above=0.)
+        total_surface_area_mm2 = gcmd.get_float("TOTAL_SURFACEAREA", above=0.) #from print data
+        largest_surface_area_mm2 = gcmd.get_float("LARGEST_SURFACEAREA", above=0.) #from print data
+        modulus_gpa = gcmd.get_float("MODULUS", above=0.) #from resin profile
+        viscosity_cps = gcmd.get_float("VISCOSITY", above=0.) #from resin profile
 
-        stage2_minspeed = gcmd.get_float("STAGE2_MINSPEED", above=0.) /60
-        stage2_maxarea = gcmd.get_float("STAGE2_MAXAREA", above=0.)
+        pos = self._get_position()
+        layer_position = pos[2]
 
-        stage2_maxspeed = gcmd.get_float("STAGE2_MAXSPEED", above=0.) /60
-        stage2_minarea = gcmd.get_float("STAGE2_MINAREA", above=0.)
+        actual_lift_distance = lift_total
+        if layer_position < self.last_resin_level:
+            actual_lift_distance = round(actual_lift_distance + (lift_total / 3))
 
-        surface_area_mm2 = gcmd.get_float("SURFACEAREA", above=0.) #from print data
+        stage1_distance = min(actual_lift_distance - 1, max(1, round(actual_lift_distance / 3 * modulus_gpa * 2) / 2))
+        stage2_distance = actual_lift_distance - stage1_distance
 
-        stage1_lift = self._calc_peel_l1(stage1_minlift,stage1_maxarea,stage1_maxlift,stage1_minarea,surface_area_mm2)
+        if layer_position < self.last_resin_level:
+            speed = max(60, round(lift_speed * 0.5 , 1))
+            stage1_distance = max(stage1_distance, round(actual_lift_distance, 2))
 
-        stage1_speed = self._calc_peel_v1(stage1_minspeed,stage1_maxarea,stage1_maxspeed,stage1_minarea,surface_area_mm2)
+        else:
+            areaRatio = largest_surface_area_mm2 / total_surface_area_mm2
+            areaFactor = pow(areaRatio, 1 / 4)
+            minSpeed = max(30, lift_speed * (1-1 / 2 * modulus_gpa))
+            stage2_distance = round((1 + stage2_distance * areaFactor),1)
+            speed = round((minSpeed + (lift_speed - minSpeed) * (1-areaFactor)) , 2)
 
-        stage2_speed = self._calc_peel_v2(stage2_minspeed,stage2_maxarea,stage2_maxspeed,stage2_minarea,surface_area_mm2)
-        logging.info(f"Computed S2 Speed: {stage2_speed}mm/s | {stage2_speed*60}mm/min")
-        gcmd.respond_raw(f"Smart Peel Computed Values - S1 Lift Distance: {stage1_lift}mm | S1 Lift Speed: {stage1_speed*60}mm/min | S2 Lift Speed: {stage2_speed*60}mm/min")
+
+        stage1Speed = max(30, round(speed * 0.15 * (1 / modulus_gpa) / 5) * 5)
+        stage2Speed = max(60, speed)
+
+        logging.warning(f"Smart Peel - Commanded Lift: {lift_total} | Stage 1 Lift: {stage1_distance} | Stage 1 Speed: {stage1Speed} | Stage 2 Lift: {stage2_distance} | Stage 2 Speed: {stage2Speed}")
+
+        lift_segment_distance = 0.2
+        target_accel = 1000.
+        base_accel = 0.1
 
         toolhead = self.printer.lookup_object('toolhead')
-
         position = self._get_position()
 
-        stage1_position = position.copy()
-        stage1_position[2] += stage1_lift
-
-        stage2_position = position.copy()
-        stage2_position[2] += lift_total
+        end_z = position[2] + stage1_distance + stage2_distance
+        end_position = position.copy()
+        end_position[2]= end_z
 
         kinematics = toolhead.get_kinematics()
 
         saved_accel_decel = kinematics.get_accel_decel()
         stage1_accel_decel = saved_accel_decel.copy()
-        stage1_accel_decel["peel_accel"] = stage1_accel
-        stage1_accel_decel["peel_decel"] = stage1_accel
-
-        stage2_accel_decel = saved_accel_decel.copy()
-        stage2_accel_decel["peel_accel"] = interstage_accel
-
+        stage1_accel_decel["peel_accel"] = base_accel
+        stage1_accel_decel["peel_decel"] = target_accel
         kinematics.set_accel_decel(stage1_accel_decel)
 
-        self._move(stage1_position,stage1_speed)
+        segments = int(stage1_distance / lift_segment_distance)
+        for i in range(1, segments):
+            pos = position.copy()
+            pos[2] += i * lift_segment_distance
+            acc = saved_accel_decel.copy()
+            acc["peel_accel"] = min(target_accel, base_accel * 2 ** i)
+            kinematics.set_accel_decel(acc)
+            self._move(pos, stage1Speed)
 
-        kinematics.set_accel_decel(stage2_accel_decel)
+        stage1_accel_decel["peel_accel"] = 1000
+        kinematics.set_accel_decel(stage1_accel_decel)
 
-        self._move(stage2_position, stage2_speed)
+        if position[2] > self.last_resin_level:
+            toolhead.wait_moves()
+            print_time = toolhead.get_last_move_time()
+
+            if not self.mcu_probe.query_endstop(print_time):
+                pos = self._probe(stage2Speed, stage2_distance)
+            else:
+                pos = [0.0, 0.0, stage1_distance + stage2_distance]
+                self._move(end_position, self.full_lift_speed)
+
+        else:
+            position[2] = end_z
+            self._move(end_position, stage2Speed)
 
         toolhead.wait_moves()
 
         kinematics.set_accel_decel(saved_accel_decel)
 
+        return pos
 
-        return self._get_position()
-
-
-
-    def _calc_v(self,P_mpa,dl,u,A,d_d):
-        v1 = ((P_mpa*math.pi*2*(d_d+dl)**3)/(3*u*A))*(600*(dl+d_d)/(math.sqrt(A/math.pi)))
-        v = min(max(v1,0.01),10)
-        return v
 
 
     def smart_dip(self, gcmd):
         #this version is an approximation of a constant pressure velocity profile using a similar scheme as a g2 command
         logging.info(f"into smart_dip command")
         mPa_to_gfmm2 = .0000102
+        modulus_to_pressure = 100000.0 #This is pure guesswork
         viscosity_cps = gcmd.get_float("VISCOSITY", above=0.) #from resin profile
         resin_level_mm = self.last_resin_level
         surface_area_mm2 = gcmd.get_float("SURFACEAREA", minval=0.) #from print data
         buildplate_area_mm2 = self.buildplate_area
         layerheight_mm = gcmd.get_float("LAYERHEIGHT", above=0.) # from slice data
-        pressure_mpa = gcmd.get_float("PRESSURE", above=0.) #from resin profile
+        modulus_gpa = gcmd.get_float("PRESSURE", above=0.) #from resin profile
+        pressure_mpa = modulus_gpa * modulus_to_pressure
         pressure_gfmm2 = pressure_mpa * mPa_to_gfmm2
 
         target_position = gcmd.get_float("TARGET", minval=0.)
         target_speed = gcmd.get_float("SPEED", minval=0.)
 
         if surface_area_mm2 > 40000 or surface_area_mm2 == 0:
-            surface_area_mm2 = 210*120*0.2
+            surface_area_mm2 = self.total_screen_area*0.2
 
         # constant factors for generating velocity profile
         resolution = self.smart_dip_segment_resolution # similar to g2 gcode
@@ -488,6 +519,13 @@ class PrinterFssProbe:
 
     def cmd_ATHENA_SET_FULL_LIFT_SPEED(self, gcmd):
         self.full_lift_speed = gcmd.get_float("VALUE", self.lift_speed * 60, minval=0.) / 60
+
+    def cmd_ATHENA_UPDATE_SCREEN_PARAMS(self,gcmd):
+        self.x_res = gcmd.get_int("XRES")
+        self.y_res = gcmd.get_int("YRES")
+        self.x_px = gcmd.get_int("XPX")
+        self.y_px = gcmd.get_int("YPX")
+        self.total_screen_area = (self.x_res * self.x_px) * (self.y_res * self.y_px)
 
 
     cmd_QUERY_FSS_help = "Return the status of the z-probe"

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -323,7 +323,9 @@ class PrinterFssProbe:
         if layer_position < effective_resin_level:
             actual_lift_distance = round(actual_lift_distance + (lift_total / 3))
 
-        stage1_distance = min(actual_lift_distance - 1, max(1, round(actual_lift_distance / 3 * modulus_gpa ,1) ))
+        #stage1_distance = min(actual_lift_distance - 1, max(1, round(actual_lift_distance / 3 * modulus_gpa ,1) ))
+        stage1_distance = min(actual_lift_distance - 1, max(1, round(actual_lift_distance / (3 * modulus_gpa), 1)))
+
         stage2_distance = actual_lift_distance - stage1_distance
 
         logging.warning(f"Smart Peel first calc run: S1D: {stage1_distance} | S2D: {stage2_distance}")

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -151,6 +151,10 @@ class PrinterFssProbe:
         p[2] += self.z_offset
         toolhead.move(p,speed)
 
+    def _reset_accel_decel(self):
+        toolhead = self.printer.lookup_object('toolhead')
+        toolhead.get_kinematics().reset_accel_decel()
+
     def _get_position(self):
         toolhead = self.printer.lookup_object('toolhead')
         p = toolhead.get_position()
@@ -200,6 +204,8 @@ class PrinterFssProbe:
         lift_segment_distance = 0.2
         target_accel = 1000.
         base_accel = 0.1
+
+        self._reset_accel_decel()
 
         toolhead = self.printer.lookup_object('toolhead')
 
@@ -292,6 +298,8 @@ class PrinterFssProbe:
             else:
                 logging.info("Skipping due to hysteresis")
 
+        self._reset_accel_decel()
+
         return pos
 
     def smart_peel(self, gcmd):
@@ -312,7 +320,6 @@ class PrinterFssProbe:
         stage2_min_speed = lift_speed / 2
 
         effective_resin_level = min(self.last_resin_level,viscosity_cps / 250.0) #this is kinda experimental
-
 
         #calculations are performed in mm/min
 
@@ -345,7 +352,6 @@ class PrinterFssProbe:
 
         actual_lift_distance = stage1_distance + stage2_distance # recompute due to likely changes in previous code
 
-        logging.warning(f"Smart Peel - Commanded Lift: {lift_total} | Stage 1 Lift: {stage1_distance} | Stage 1 Speed: {stage1Speed} | Stage 2 Lift: {stage2_distance} | Stage 2 Speed: {stage2Speed}")
         #convert speeds to mm/s for klipper:
         stage1Speed = round(stage1Speed / 60, 2)
         stage2Speed = round(stage2Speed / 60, 2)
@@ -362,6 +368,7 @@ class PrinterFssProbe:
         end_position[2]= end_z
 
         kinematics = toolhead.get_kinematics()
+        self._reset_accel_decel()
 
         saved_accel_decel = kinematics.get_accel_decel()
         stage1_accel_decel = saved_accel_decel.copy()
@@ -386,6 +393,7 @@ class PrinterFssProbe:
         if position[2] > self.last_resin_level:
             toolhead.wait_moves()
             print_time = toolhead.get_last_move_time()
+            self._reset_accel_decel()
 
             if not self.mcu_probe.query_endstop(print_time):
                 logging.warning(f"Smart Peel - Above Resin Level - PeelDetection Not Triggered")
@@ -415,7 +423,9 @@ class PrinterFssProbe:
         toolhead.wait_moves()
 
         kinematics.set_accel_decel(saved_accel_decel)
-        logstr = f"Smart Peel Move Stats - Stage 1 Lift: {stage1_distance} | Stage 2 Lift: {stage2_distance} | Peel Detection: "
+        logging.warning(f"Smart Peel - Commanded Lift: {lift_total} | Stage 1 Lift: {stage1_distance} | Stage 1 Speed: {stage1Speed} | Stage 2 Lift: {stage2_distance} | Stage 2 Speed: {stage2Speed}")
+
+        logstr = f"Smart Peel Move Stats - CL:{lift_total} | AL:{actual_lift_distance} | S1L:{stage1_distance} | S2L:{stage2_distance} | S1S:{stage1Speed*60.0} | S2S:{stage2Speed*60.0} | PDT:{pd_trigger_position} | Peel Detection: "
         if pd_trigger_position == 0.0:
             logstr += "Disabled"
         elif pd_trigger_position == stage1_distance:
@@ -426,12 +436,15 @@ class PrinterFssProbe:
             logstr += f"During Stage 2 at {pd_trigger_position}mm ({round((pd_trigger_position/actual_lift_distance)*100)}% of total move"
         logging.warning(logstr)
 
+        self._reset_accel_decel()
+
         return pos
 
 
 
     def smart_dip(self, gcmd):
         #this version is an approximation of a constant pressure velocity profile using a similar scheme as a g2 command
+        self._reset_accel_decel()
         mPa_to_gfmm2 = .0000102
         modulus_to_pressure = 100000.0 #This is pure guesswork
         viscosity_cps = gcmd.get_float("VISCOSITY", above=0.) #from resin profile
@@ -500,6 +513,7 @@ class PrinterFssProbe:
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.wait_moves()
         pos = self._get_position()
+        self._reset_accel_decel()
 
         return pos
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -307,7 +307,7 @@ class PrinterFssProbe:
         stage2_max_speed = self.full_lift_speed * 60
         stage2_min_speed = lift_speed / 2
 
-        effective_resin_level = min(self.last_resin_level,viscosity_cps / 1000.0) #this is kinda experimental
+        effective_resin_level = min(self.last_resin_level,viscosity_cps / 250.0) #this is kinda experimental
 
 
         #calculations are performed in mm/min

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -360,11 +360,12 @@ class PrinterFssProbe:
         pressure_gfmm2 = pressure_mpa * mPa_to_gfmm2
 
         target_position = gcmd.get_float("TARGET", minval=0.)
+        target_speed = gcmd.get_float("SPEED", minval=0.)
 
         # constant factors for generating velocity profile
         resolution = 0.005 # similar to g2 gcode
         vmin = 0.05 # minimum velocity 0.3mm/min
-        vmax = 10   # maximum velocity 600mm/min
+        vmax = target_speed / 60   # maximum velocity 600mm/min
         max_force = 20000 #maximum force a retract move will try to achieve
         viscosity_coefficient = 60   #constant for movements outside of squeezing flow regime
         e_plate_area = buildplate_area_mm2 * 0.75 # the circular eqiuvalent area which produces the same constant pressure curve

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -386,6 +386,8 @@ class PrinterFssProbe:
                     logging.warning(f"Smart Peel - PeelDetection Triggered - Doing final move")
                     pd_trigger_position = pos[2] + stage1_distance
                     self._move(end_position, self.full_lift_speed)
+                else:
+                    pd_trigger_position = actual_lift_distance
 
             else:
                 logging.warning(f"Smart Peel - Above Resin Level - PeelDetection Triggered")
@@ -406,6 +408,8 @@ class PrinterFssProbe:
             logstr += "Disabled"
         elif pd_trigger_position == stage1_distance:
             logstr += "During Stage 1"
+        elif pd_trigger_position == actual_lift_distance:
+            logstr+= "Not Triggered"
         else:
             logstr += f"During Stage 2 at {pd_trigger_position}mm ({round((pd_trigger_position/actual_lift_distance)*100)}% of total move"
         logging.warning(logstr)

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -427,7 +427,6 @@ class PrinterFssProbe:
 
     def smart_dip(self, gcmd):
         #this version is an approximation of a constant pressure velocity profile using a similar scheme as a g2 command
-        logging.info(f"into smart_dip command")
         mPa_to_gfmm2 = .0000102
         modulus_to_pressure = 100000.0 #This is pure guesswork
         viscosity_cps = gcmd.get_float("VISCOSITY", above=0.) #from resin profile
@@ -454,7 +453,6 @@ class PrinterFssProbe:
         e_plate_area = buildplate_area_mm2 * 0.75 # the circular eqiuvalent area which produces the same constant pressure curve
         pressure_mpa_maxforce = (max_force/e_plate_area)/mPa_to_gfmm2    #pressure on build plate corresponding to maximum force
 
-        toolhead = self.printer.lookup_object('toolhead')
         pos = self._get_position()
         dip_amount = pos[2] - target_position
 
@@ -469,7 +467,7 @@ class PrinterFssProbe:
 
         d_d = max(0.1,(0.218*((surface_area_mm2*pressure_gfmm2)**0.821)) / 1000)    # maximum arm deflection from retract force on layer area
         d_d2 = max(0.1, (0.218 * (max_force ** 0.821)) / 1000) # maximum arm deflection due to force on build plate
-        logging.info(f"Actual Dip Amount {dip_amount}, Target Z {target_position}")
+        logging.info(f"Actual Dip Amount {dip_amount}, Target Z {target_position}, First Stage Amound: {dip_first_stage}, First Stage Target: {first_stage_target_position[2]}, Second Stage: {dip_second_stage}")
 
         segments = max(1., math.floor(dip_second_stage / resolution))
 
@@ -477,7 +475,7 @@ class PrinterFssProbe:
             for i in range(1, int(segments) + 1):
                 step_pos = [0. , 0. , 0. , 0.]
                 step_pos[2] =  first_stage_target_position[2] - (i * resolution)
-                di = dip_amount + layerheight_mm - (i*resolution)
+                di = dip_second_stage + layerheight_mm - (i*resolution)
                 # velocity = minimum of velocity for maximum part pressure or velocity corresponding with maximum force
                 v1 = (3*(pressure_mpa*math.pi*2*(d_d+di)**3)/(3*viscosity_cps*surface_area_mm2))*(1 + (viscosity_coefficient*math.atan(((di)+d_d)/(math.sqrt(surface_area_mm2/math.pi)))))
                 v2 = ((pressure_mpa_maxforce*math.pi*2*(d_d2+di)**3)/(3*viscosity_cps*e_plate_area))*(1 + (viscosity_coefficient*math.atan(((di)+d_d2)/(math.sqrt(e_plate_area/math.pi)))))
@@ -489,11 +487,12 @@ class PrinterFssProbe:
             for i in range(1, int(segments) + 1):
                 step_pos = [0. , 0. , 0. , 0.]
                 step_pos[2] =  first_stage_target_position[2] - (i * resolution)
-                di = dip_amount + layerheight_mm - (i*resolution)
+                di = dip_second_stage + layerheight_mm - (i*resolution)
                 v1 = (3*(pressure_mpa*math.pi*2*(d_d+di)**3)/(3*viscosity_cps*surface_area_mm2))*(1 + (viscosity_coefficient*math.atan(((di)+d_d)/(math.sqrt(surface_area_mm2/math.pi)))))
                 velocity = min(max(v1,vmin),vmax)
                 self._move(step_pos,velocity)
 
+        toolhead = self.printer.lookup_object('toolhead')
         toolhead.wait_moves()
         pos = self._get_position()
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -184,7 +184,7 @@ class PrinterFssProbe:
     def run_probe_upwards(self, gcmd):
         lift_amount = gcmd.get_float("Z", self.lift_amount, minval=0.)
         lift_speed = gcmd.get_float("F", self.lift_speed, above=0.) / 60
-        stage1_lift_distance = 0.5
+        stage1_lift_distance = 0.2
         toolhead = self.printer.lookup_object('toolhead')
 
         position = self._get_position()
@@ -196,7 +196,7 @@ class PrinterFssProbe:
 
         saved_accel_decel = kinematics.get_accel_decel()
         stage1_accel_decel = saved_accel_decel.copy()
-        stage1_accel_decel["peel_accel"] = .5
+        stage1_accel_decel["peel_accel"] = .1
         stage1_accel_decel["peel_decel"] = 1000
         kinematics.set_accel_decel(stage1_accel_decel)
 
@@ -388,12 +388,12 @@ class PrinterFssProbe:
 
         if target_position < 0.5:
             deflection = ((d_d2*ilaC)*(1-(target_position*2))+((d_d*ilaC)*(target_position*2)))
-            segments = max(1., math.floor((dip_amount+deflection) / resolution))
-            logging.info(f"Deflection {deflection}, Segments {segments}")
         else:
             deflection = (d_d*ilaC)
-            segments = max(1., math.floor((dip_amount+deflection) / resolution))
 
+        deflection = 0
+
+        segments = max(1., math.floor((dip_amount+deflection) / resolution))
         logging.info(f"Deflection {deflection}, Segments {segments}")
 
         if target_position < resin_level_mm:
@@ -417,7 +417,7 @@ class PrinterFssProbe:
                 velocity = min(max(v1,vmin),vmax)
                 self._move(step_pos,velocity)
 
-        self._move([0,0,target_position,0],5)
+        #self._move([0,0,target_position,0],5)
         toolhead.wait_moves()
         pos = self._get_position()
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -527,7 +527,8 @@ class PrinterFssProbe:
             pos = self._get_position()
             pos[2] = target_position
             self._move(pos,target_speed)
-            self.toolhead.wait_moves()
+            toolhead = self.printer.lookup_object('toolhead')
+            toolhead.wait_moves()
 
         else:
             self.smart_dip(gcmd)
@@ -654,7 +655,7 @@ class PrinterFssProbe:
         self.last_exposure_post_delay = gcmd.get_float("POST_DELAY", 0 )
         self.last_gcmd = gcmd
 
-        self.toolhead = self.printer.lookup_object('toolhead')
+        toolhead = self.printer.lookup_object('toolhead')
         self.ledpwm = self.printer.lookup_object('output_pin LEDPWM')
 
 
@@ -667,7 +668,7 @@ class PrinterFssProbe:
                 self.resinheater.set_temp(0.0)
 
         self.exposure_active_flag = True
-        self.toolhead.register_lookahead_callback(self.exposure_timing_callback)
+        toolhead.register_lookahead_callback(self.exposure_timing_callback)
 
 
     def get_status(self, eventtime):

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -34,6 +34,8 @@ class PrinterFssProbe:
         self.last_z_result = 0.
         self.gcode_move = self.printer.load_object(config, "gcode_move")
 
+        self.exposure_calibration = 1.0
+
         self.last_exposure_time = 0
         self.last_exposure_power = 0
         self.last_exposure_pre_delay = 0
@@ -87,6 +89,9 @@ class PrinterFssProbe:
 
         self.gcode.register_command('EXPOSE', self.cmd_EXPOSE,
                                     desc=self.cmd_EXPOSE_help)
+
+        self.gcode.register_command('SET_EXPOSE_CALIBRATION', self.cmd_SET_EXPOSE_CALIBRATION,
+                                    desc=self.cmd_SET_EXPOSE_CALIBRATION)
 
         self.gcode.register_command('ATHENA_SET_PEELMODE_MINIMAL', self.cmd_ATHENA_SET_PEELMODE_MINIMAL)
 
@@ -268,10 +273,13 @@ class PrinterFssProbe:
 
         self.last_gcmd.respond_raw("Z_move_comp")
 
+    cmd_EXPOSE_help = "Sets the exposure power calibration value"
+    def cmd_SET_EXPOSE_CALIBRATION(self,gcmd):
+        self.exposure_calibration = gcmd.get_float("VALUE", 1 , above=0.)
 
     cmd_EXPOSE_help = "Exposes a layer for a given time with a given PWM setting"
     def cmd_EXPOSE(self, gcmd):
-        self.last_exposure_power = gcmd.get_float("PWM", 0.1 , above=0.)
+        self.last_exposure_power = gcmd.get_float("PWM", 0.1 , above=0.) * self.exposure_calibration
         self.last_exposure_time = gcmd.get_float("TIME", 1.0 , above=0.)
         self.last_exposure_pre_delay = gcmd.get_float("PRE_DELAY", 0 )
         self.last_exposure_post_delay = gcmd.get_float("POST_DELAY", 0 )

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -228,23 +228,42 @@ class PrinterFssProbe:
         speed = coeff * (area - s2_maxarea) + s2_minspeed
         return max(min(speed,s2_maxspeed),s2_minspeed)
 
+    def _calc_peel_v1(self,s1_minspeed, s1_maxarea, s1_maxspeed, s1_minarea,area):
+        coeff = (s1_maxspeed - s1_minspeed) / (s1_minarea - s1_maxarea)
+        speedv1 = coeff * (area - s1_maxarea) + s1_minspeed
+        return max(min(speedv1,s1_maxspeed),s1_minspeed)
+
+    def _calc_peel_l1(self,s1_minlift, s1_maxarea, s1_maxlift, s1_minarea,area):
+        coeff = (s1_maxlift - s1_minlift) / (s1_minarea - s1_maxarea)
+        lifts1 = coeff * (area - s1_maxarea) + s1_minlift
+        return max(min(lifts1,s1_maxlift),s1_minlift)
+
     def smart_peel(self, gcmd):
-        lift_total = gcmd.get_float("LIFT_TOTAL",  minval=0.)
-        stage1_lift = gcmd.get_float("STAGE1_LIFT",  minval=0.)
-        stage1_speed_mms = gcmd.get_float("STAGE1_SPEED",  minval=0.) / 60
-        stage1_accel = gcmd.get_float("STAGE1_ACCEL",  minval=0.)
-        interstage_accel = gcmd.get_float("INTERSTAGE_ACCEL",  minval=0.)
+        lift_total = gcmd.get_float("LIFT_TOTAL", above=0.)
+        stage1_minlift = gcmd.get_float("STAGE1_MINLIFT", above=0.)
+        stage1_maxlift = gcmd.get_float("STAGE1_MAXLIFT", above=0.)
+        stage1_minspeed = gcmd.get_float("STAGE1_MINSPEED", above=0.) / 60
+        stage1_maxspeed = gcmd.get_float("STAGE1_MAXSPEED", above=0.) / 60
+        stage1_accel = gcmd.get_float("STAGE1_ACCEL", above=0.)
+        interstage_accel = gcmd.get_float("INTERSTAGE_ACCEL", above=0.)
 
-        stage2_minspeed = gcmd.get_float("STAGE2_MINSPEED",  minval=0.)
-        stage2_maxarea = gcmd.get_float("STAGE2_MAXAREA",  minval=0.)
+        stage1_maxarea = gcmd.get_float("STAGE1_MAXAREA", above=0.)
+        stage1_minarea = gcmd.get_float("STAGE1_MINAREA", above=0.)
 
-        stage2_maxspeed = gcmd.get_float("STAGE2_MAXSPEED",  minval=0.)
-        stage2_minarea = gcmd.get_float("STAGE2_MINAREA",  minval=0.)
+        stage2_minspeed = gcmd.get_float("STAGE2_MINSPEED", above=0.) /60
+        stage2_maxarea = gcmd.get_float("STAGE2_MAXAREA", above=0.)
+
+        stage2_maxspeed = gcmd.get_float("STAGE2_MAXSPEED", above=0.) /60
+        stage2_minarea = gcmd.get_float("STAGE2_MINAREA", above=0.)
 
         surface_area_mm2 = gcmd.get_float("SURFACEAREA", above=0.) #from print data
 
-        stage2_speed_mms = self._calc_peel_v2(stage2_minspeed,stage2_maxarea,stage2_maxspeed,stage2_minarea,surface_area_mm2) / 60
-        logging.info(f"Computed S2 Speed: {stage2_speed_mms}mm/s | {stage2_speed_mms*60}mm/min")
+        stage1_lift = self._calc_peel_l1(stage1_minlift,stage1_maxarea,stage1_maxlift,stage1_minarea,surface_area_mm2)
+
+        stage1_speed = self._calc_peel_v1(stage1_minspeed,stage1_maxarea,stage1_maxspeed,stage1_minarea,surface_area_mm2)
+
+        stage2_speed = self._calc_peel_v2(stage2_minspeed,stage2_maxarea,stage2_maxspeed,stage2_minarea,surface_area_mm2)
+        logging.info(f"Computed S2 Speed: {stage2_speed}mm/s | {stage2_speed*60}mm/min")
         toolhead = self.printer.lookup_object('toolhead')
 
         position = toolhead.get_position()
@@ -252,7 +271,7 @@ class PrinterFssProbe:
         stage1_position = position.copy()
         stage1_position[2] += stage1_lift
 
-        stage2_position = position.copy()
+        stage2_position = stage1_position
         stage2_position[2] += lift_total
 
         kinematics = toolhead.get_kinematics()
@@ -267,11 +286,11 @@ class PrinterFssProbe:
 
         kinematics.set_accel_decel(stage1_accel_decel)
 
-        toolhead.move(stage1_position,stage1_speed_mms)
+        toolhead.move(stage1_position,stage1_speed)
 
         kinematics.set_accel_decel(stage2_accel_decel)
 
-        toolhead.move(stage2_position, stage2_speed_mms)
+        toolhead.move(stage2_position, stage2_speed)
 
         toolhead.wait_moves()
 
@@ -287,9 +306,7 @@ class PrinterFssProbe:
 
         return top/bot
 
-    def _calc_v2(self,P,dl,u,A,v2p1):
-        mPa_to_gfmm2 = .0000102
-        P_gfmm2 = P * mPa_to_gfmm2
+    def _calc_v2(self,P,P_gfmm2,dl,u,A,v2p1):
 
         d_d =( (0.0362 * P_gfmm2 * A) - ( 9.81 * 10**-8 * (P_gfmm2*A)**2 )) / 1000
 
@@ -350,20 +367,22 @@ class PrinterFssProbe:
         return x
 
     def smart_dip(self, gcmd):
-
+        mPa_to_gfmm2 = .0000102
         viscosity_cps = gcmd.get_float("VISCOSITY", above=0.) #from resin profile
         resin_level_mm = self.last_resin_level
         surface_area_mm2 = gcmd.get_float("SURFACEAREA", above=0.) #from print data
         buildplate_area_mm2 = self.buildplate_area
         layerheight_mm = gcmd.get_float("LAYERHEIGHT", above=0.) # from slice data
         pressure_mpa = gcmd.get_float("PRESSURE", above=0.) #from resin profile
+        pressure_gfmm2 = pressure_mpa * mPa_to_gfmm2
+
         target_position = gcmd.get_float("TARGET", minval=0.)
 
         v1p1 = gcmd.get_float("V1P1", 8, minval=1)
         v1p2 = gcmd.get_float("V1P2", 1.5, minval=1)
         v2p1 = gcmd.get_float("V2P1", 2, minval=0)
 
-        vmin = gcmd.get_float("VMIN", 2, minval=0)
+        vmin = gcmd.get_float("VMIN", 2, minval=0) / 60
 
         toolhead = self.printer.lookup_object('toolhead')
         pos = toolhead.get_position()
@@ -378,7 +397,11 @@ class PrinterFssProbe:
             surface_area_mm2 = min(surface_area_mm2,buildplate_area_mm2)
             logging.info(f"Offset surface area to {surface_area_mm2}, factor {build_area_factor}")
 
-        v2 = max(vmin,self._calc_v2(pressure_mpa,layerheight_mm,viscosity_cps,surface_area_mm2,v2p1))
+        if (pressure_gfmm2*surface_area_mm2 > 20000):		# function to limit the maximum force the printer will try to achieve so it doesnt skip steps.
+            pressure_gfmm2 = 30000/surface_area_mm2
+            pressure_mpa = pressure_gfmm2/mPa_to_gfmm2
+
+        v2 = max(vmin,self._calc_v2(pressure_mpa,pressure_gfmm2,layerheight_mm,viscosity_cps,surface_area_mm2,v2p1))
         r2 = self._optimize_r2(v2,viscosity_cps,surface_area_mm2, pressure_mpa,dip_amount)
         r1 = dip_amount - r2
         v1 = max(vmin,self._calc_v1(r2,pressure_mpa,viscosity_cps,surface_area_mm2,v1p1,v1p2))

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -299,8 +299,13 @@ class PrinterFssProbe:
         modulus_gpa = gcmd.get_float("MODULUS", above=0.) #from resin profile
         viscosity_cps = gcmd.get_float("VISCOSITY", above=0.) #from resin profile
 
-        stage1_max_speed = lift_speed / 4
+        stage1_max_speed = lift_speed / 2
+        stage1_min_speed = lift_speed / 4
         stage2_max_speed = self.full_lift_speed * 60
+        stage2_min_speed = lift_speed / 2
+
+        effective_resin_level = min(self.last_resin_level,viscosity_cps / 1000.0) #this is kinda experimental
+
 
         #calculations are performed in mm/min
 
@@ -312,28 +317,28 @@ class PrinterFssProbe:
 
         logging.warning(f"Smart Peel Using {actual_lift_distance}mm Lift")
 
-        if layer_position < self.last_resin_level:
+        if layer_position < effective_resin_level:
             actual_lift_distance = round(actual_lift_distance + (lift_total / 3))
 
-        stage1_distance = min(actual_lift_distance - 1, max(1, round(actual_lift_distance / 3 * modulus_gpa * 2) / 2))
+        stage1_distance = min(actual_lift_distance - 1, max(1, round(actual_lift_distance / 3 * modulus_gpa ,1) ))
         stage2_distance = actual_lift_distance - stage1_distance
 
         logging.warning(f"Smart Peel first calc run: S1D: {stage1_distance} | S2D: {stage2_distance}")
 
-        if layer_position < self.last_resin_level:
-            speed = max(stage1_max_speed, round(lift_speed/2 , 1))
+        if layer_position < effective_resin_level:
+            speed = max(stage2_max_speed, round(lift_speed/2 , 1))
             stage1_distance = max(stage1_distance, round(actual_lift_distance/2, 2))
 
         else:
             areaRatio = largest_surface_area_mm2 / total_surface_area_mm2
             areaFactor = pow(areaRatio, 1 / 4)
-            minSpeed = max(stage1_max_speed, lift_speed * (1-1 / 2 * modulus_gpa))
+            minSpeed = max(stage1_max_speed, lift_speed * (1 - 1/2 * modulus_gpa))
             stage2_distance = round((1 + stage2_distance * areaFactor),1)
             speed = round((minSpeed + (lift_speed - minSpeed) * (1-areaFactor)) , 2)
 
 
-        stage1Speed = min(stage1_max_speed, round(speed * 0.15 * (1 / modulus_gpa),2))
-        stage2Speed = min(stage2_max_speed, speed)
+        stage1Speed = max(stage1_min_speed, round(speed * 0.15 * (1 / modulus_gpa),2))
+        stage2Speed = max(stage2_min_speed, speed)
 
         actual_lift_distance = stage1_distance + stage2_distance # recompute due to likely changes in previous code
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -453,8 +453,6 @@ class PrinterFssProbe:
         viscosity_coefficient = 60   #constant for movements outside of squeezing flow regime
         e_plate_area = buildplate_area_mm2 * 0.75 # the circular eqiuvalent area which produces the same constant pressure curve
         pressure_mpa_maxforce = (max_force/e_plate_area)/mPa_to_gfmm2    #pressure on build plate corresponding to maximum force
-        ilaC = 0.5 #Initial layer accuracy coefficient, determines the amount of overshoot on the first layers for better layer thickness accuracy, increases first layer time
-
 
         toolhead = self.printer.lookup_object('toolhead')
         pos = self._get_position()
@@ -462,6 +460,11 @@ class PrinterFssProbe:
 
         dip_first_stage = dip_amount * 0.8
         dip_second_stage = dip_amount - dip_first_stage
+
+        first_stage_target_position = pos.copy()
+
+        first_stage_target_position[2] = first_stage_target_position - dip_first_stage
+        self._move(first_stage_target_position,vmax)
 
 
         d_d = max(0.1,(0.218*((surface_area_mm2*pressure_gfmm2)**0.821)) / 1000)    # maximum arm deflection from retract force on layer area
@@ -473,7 +476,7 @@ class PrinterFssProbe:
         if target_position < resin_level_mm:
             for i in range(1, int(segments) + 1):
                 step_pos = [0. , 0. , 0. , 0.]
-                step_pos[2] =  pos[2] - (i * resolution)
+                step_pos[2] =  first_stage_target_position[2] - (i * resolution)
                 di = dip_amount + layerheight_mm - (i*resolution)
                 # velocity = minimum of velocity for maximum part pressure or velocity corresponding with maximum force
                 v1 = (3*(pressure_mpa*math.pi*2*(d_d+di)**3)/(3*viscosity_cps*surface_area_mm2))*(1 + (viscosity_coefficient*math.atan(((di)+d_d)/(math.sqrt(surface_area_mm2/math.pi)))))
@@ -485,13 +488,12 @@ class PrinterFssProbe:
         else:
             for i in range(1, int(segments) + 1):
                 step_pos = [0. , 0. , 0. , 0.]
-                step_pos[2] =  pos[2] - (i * resolution)
+                step_pos[2] =  first_stage_target_position[2] - (i * resolution)
                 di = dip_amount + layerheight_mm - (i*resolution)
                 v1 = (3*(pressure_mpa*math.pi*2*(d_d+di)**3)/(3*viscosity_cps*surface_area_mm2))*(1 + (viscosity_coefficient*math.atan(((di)+d_d)/(math.sqrt(surface_area_mm2/math.pi)))))
                 velocity = min(max(v1,vmin),vmax)
                 self._move(step_pos,velocity)
 
-        #self._move([0,0,target_position,0],5)
         toolhead.wait_moves()
         pos = self._get_position()
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -292,39 +292,55 @@ class PrinterFssProbe:
 
     def smart_peel(self, gcmd):
         lift_total = gcmd.get_float("LIFT_TOTAL", above=0.)
-        lift_speed = gcmd.get_float("SPEED", self.lift_speed, above=0.) / 60
+        lift_speed = gcmd.get_float("SPEED", self.lift_speed, above=0.)
 
         total_surface_area_mm2 = gcmd.get_float("TOTAL_SURFACEAREA", above=0.) #from print data
         largest_surface_area_mm2 = gcmd.get_float("LARGEST_SURFACEAREA", above=0.) #from print data
         modulus_gpa = gcmd.get_float("MODULUS", above=0.) #from resin profile
         viscosity_cps = gcmd.get_float("VISCOSITY", above=0.) #from resin profile
 
+        stage1_max_speed = lift_speed / 4
+        stage2_max_speed = self.full_lift_speed * 60
+
+        #calculations are performed in mm/min
+
         pos = self._get_position()
         layer_position = pos[2]
 
-        actual_lift_distance = lift_total
+        estimated_lift_distance = 4 + min(4,2/modulus_gpa)
+        actual_lift_distance = max(lift_total,estimated_lift_distance)
+
+        logging.warning(f"Smart Peel Using {actual_lift_distance}mm Lift")
+
         if layer_position < self.last_resin_level:
             actual_lift_distance = round(actual_lift_distance + (lift_total / 3))
 
         stage1_distance = min(actual_lift_distance - 1, max(1, round(actual_lift_distance / 3 * modulus_gpa * 2) / 2))
         stage2_distance = actual_lift_distance - stage1_distance
 
+        logging.warning(f"Smart Peel first calc run: S1D: {stage1_distance} | S2D: {stage2_distance}")
+
         if layer_position < self.last_resin_level:
-            speed = max(60, round(lift_speed * 0.5 , 1))
-            stage1_distance = max(stage1_distance, round(actual_lift_distance, 2))
+            speed = max(stage1_max_speed, round(lift_speed/2 , 1))
+            stage1_distance = max(stage1_distance, round(actual_lift_distance/2, 2))
 
         else:
             areaRatio = largest_surface_area_mm2 / total_surface_area_mm2
             areaFactor = pow(areaRatio, 1 / 4)
-            minSpeed = max(30, lift_speed * (1-1 / 2 * modulus_gpa))
+            minSpeed = max(stage1_max_speed, lift_speed * (1-1 / 2 * modulus_gpa))
             stage2_distance = round((1 + stage2_distance * areaFactor),1)
             speed = round((minSpeed + (lift_speed - minSpeed) * (1-areaFactor)) , 2)
 
 
-        stage1Speed = max(30, round(speed * 0.15 * (1 / modulus_gpa) / 5) * 5)
-        stage2Speed = max(60, speed)
+        stage1Speed = min(stage1_max_speed, round(speed * 0.15 * (1 / modulus_gpa) / 5) * 5)
+        stage2Speed = min(stage2_max_speed, speed)
+
+        actual_lift_distance = stage1_distance + stage2_distance # recompute due to likely changes in previous code
 
         logging.warning(f"Smart Peel - Commanded Lift: {lift_total} | Stage 1 Lift: {stage1_distance} | Stage 1 Speed: {stage1Speed} | Stage 2 Lift: {stage2_distance} | Stage 2 Speed: {stage2Speed}")
+        #convert speeds to mm/s for klipper:
+        stage1Speed = round(stage1Speed / 60, 2)
+        stage2Speed = round(stage2Speed / 60, 2)
 
         lift_segment_distance = 0.2
         target_accel = 1000.
@@ -357,23 +373,42 @@ class PrinterFssProbe:
         stage1_accel_decel["peel_accel"] = 1000
         kinematics.set_accel_decel(stage1_accel_decel)
 
+        pd_trigger_position = 0.0
+
         if position[2] > self.last_resin_level:
             toolhead.wait_moves()
             print_time = toolhead.get_last_move_time()
 
             if not self.mcu_probe.query_endstop(print_time):
+                logging.warning(f"Smart Peel - Above Resin Level - PeelDetection Not Triggered")
                 pos = self._probe(stage2Speed, stage2_distance)
+                if pos[2] != stage2_distance:
+                    logging.warning(f"Smart Peel - PeelDetection Triggered - Doing final move")
+                    pd_trigger_position = pos[2] + stage1_distance
+                    self._move(end_position, self.full_lift_speed)
+
             else:
-                pos = [0.0, 0.0, stage1_distance + stage2_distance]
+                logging.warning(f"Smart Peel - Above Resin Level - PeelDetection Triggered")
+                pd_trigger_position = stage1_distance
+                pos = [0.0, 0.0, actual_lift_distance]
                 self._move(end_position, self.full_lift_speed)
 
         else:
-            position[2] = end_z
+            logging.warning(f"Smart Peel - Below Resin Level - PeelDetection Disabled")
+            pos = [0.0, 0.0, actual_lift_distance]
             self._move(end_position, stage2Speed)
 
         toolhead.wait_moves()
 
         kinematics.set_accel_decel(saved_accel_decel)
+        logstr = f"Smart Peel Move Stats - Stage 1 Lift: {stage1_distance} | Stage 2 Lift: {stage2_distance} | Peel Detection: "
+        if pd_trigger_position == 0.0:
+            logstr += "Disabled"
+        elif pd_trigger_position == stage1_distance:
+            logstr += "During Stage 1"
+        else:
+            logstr += f"During Stage 2 at {pd_trigger_position}mm ({round((pd_trigger_position/actual_lift_distance)*100)}% of total move"
+        logging.warning(logstr)
 
         return pos
 
@@ -482,8 +517,11 @@ class PrinterFssProbe:
         gcmd.respond_raw("Z_move_comp")
 
     def cmd_ATHENA_SMART_PEEL(self,gcmd):
-        self.smart_peel(gcmd)
+        pos = self.smart_peel(gcmd)
         gcmd.respond_raw("Z_move_comp")
+        gcmd.respond_info("Result is z=%.6f" % (pos[2],))
+        self.last_z_result = pos[2]
+
 
 
     def cmd_ATHENA_PROBE_UPWARDS(self, gcmd):

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -264,6 +264,8 @@ class PrinterFssProbe:
 
         stage2_speed = self._calc_peel_v2(stage2_minspeed,stage2_maxarea,stage2_maxspeed,stage2_minarea,surface_area_mm2)
         logging.info(f"Computed S2 Speed: {stage2_speed}mm/s | {stage2_speed*60}mm/min")
+        gcmd.respond_raw(f"Smart Peel Computed Values - S1 Lift Distance: {stage1_lift}mm | S1 Lift Speed: {stage1_speed*60}mm/min | S2 Lift Speed: {stage2_speed*60}mm/min")
+
         toolhead = self.printer.lookup_object('toolhead')
 
         position = toolhead.get_position()
@@ -407,6 +409,7 @@ class PrinterFssProbe:
         v1 = max(vmin,self._calc_v1(r2,pressure_mpa,viscosity_cps,surface_area_mm2,v1p1,v1p2))
 
         logging.info(f"Two-Stage Retract calculated: R1: {r1} | V1: {v1} | R2: {r2} | V2: {v2}")
+        gcmd.respond_raw(f"Smart Retract Computed Values - S1 Distance: {r1}mm | S1 Speed: {v1*60}mm/min | S2 Distance: {r2}mm | S2 Lift Speed: {v2*60}mm/min")
 
         pos1 = pos
         pos1[2] -= r1

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -258,8 +258,8 @@ class PrinterFssProbe:
 
         self.reactor.register_callback(self.exposure_done_callback, reactor_time+self.last_exposure_time+self.expose_processing_delay*2+self.last_exposure_pre_delay+self.last_exposure_post_delay)
 
-        self.ledpwm.mcu_pin.set_pwm(print_time+self.expose_processing_delay+self.last_exposure_pre_delay, self.last_exposure_power, 0.001)
-        self.ledpwm.mcu_pin.set_pwm(print_time+self.expose_processing_delay+self.last_exposure_pre_delay+self.last_exposure_time, 0, 0.001)
+        self.ledpwm.mcu_pin.set_pwm(print_time+self.expose_processing_delay+self.last_exposure_pre_delay, self.last_exposure_power)
+        self.ledpwm.mcu_pin.set_pwm(print_time+self.expose_processing_delay+self.last_exposure_pre_delay+self.last_exposure_time, 0)
 
     def exposure_done_callback(self, print_time):
 

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -183,10 +183,27 @@ class PrinterFssProbe:
     def run_probe_upwards(self, gcmd):
         lift_amount = gcmd.get_float("Z", self.lift_amount, minval=0.)
         lift_speed = gcmd.get_float("F", self.lift_speed, above=0.) / 60
-
-        pos = self._probe(lift_speed, lift_amount)
-
         toolhead = self.printer.lookup_object('toolhead')
+
+        position = self._get_position()
+
+        stage1_position = position.copy()
+        stage1_position[2] += 0.5
+
+        kinematics = toolhead.get_kinematics()
+
+        saved_accel_decel = kinematics.get_accel_decel()
+        stage1_accel_decel = saved_accel_decel.copy()
+        stage1_accel_decel["peel_accel"] = .5
+        stage1_accel_decel["peel_decel"] = 1
+        kinematics.set_accel_decel(stage1_accel_decel)
+
+        self._move(stage1_position,lift_speed)
+
+        kinematics.set_accel_decel(saved_accel_decel)
+
+        pos = self._probe(lift_speed, lift_amount-.5)
+
 
         if self.peelmode == "minimal":
             if pos[2] < self.min_lift_distance:

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -244,18 +244,18 @@ class PrinterFssProbe:
         surface_area_mm2 = gcmd.get_float("SURFACEAREA", above=0.) #from print data
 
         stage2_speed_mms = self._calc_peel_v2(stage2_minspeed,stage2_maxarea,stage2_maxspeed,stage2_minarea,surface_area_mm2) / 60
-
+        logging.info(f"Computed S2 Speed: {stage2_speed_mms}mm/s | {stage2_speed_mms*60}mm/min")
         toolhead = self.printer.lookup_object('toolhead')
 
         position = toolhead.get_position()
 
-        stage1_position = position
+        stage1_position = position.copy()
         stage1_position[2] += stage1_lift
 
-        stage2_position = position
-        stage2_position += lift_total
+        stage2_position = position.copy()
+        stage2_position[2] += lift_total
 
-        kinematics = self.toolhead.get_kinematics()
+        kinematics = toolhead.get_kinematics()
 
         saved_accel_decel = kinematics.get_accel_decel()
         stage1_accel_decel = saved_accel_decel.copy()
@@ -273,28 +273,35 @@ class PrinterFssProbe:
 
         toolhead.move(stage2_position, stage2_speed_mms)
 
+        toolhead.wait_moves()
+
         kinematics.set_accel_decel(saved_accel_decel)
 
-        toolhead.wait_moves()
 
         return toolhead.get_position()
 
     def _calc_v1(self,r2,P,u,A):
 
-        top = 2 * math.pi * P * pow(r2,3)
-        bot = 3 + u + A
+        top = 2 * math.pi * P * r2**3
+        bot = 3 * u * A
 
         return top/bot
 
     def _calc_v2(self,P,dl,u,A):
-        Cf = 0.0362 - ( 9.81 * pow(10,-8))
+        d_d =( (0.0362 * P * A) - ( 9.81 * 10**-8 * (P*A)**2 )) / 1000
 
-        top = 2 * math.pi + pow( dl + Cf * P * A, 3)
+        logging.info(f"Calc V2: d_d: {d_d} | P: {P} | dl: {dl} | u: {u} | A: {A}")
+
+        top = 2 * math.pi * ( dl + d_d)**3
         bot = 3 * u * A
+
+        logging.info(f"Calc V2: Top: {top} | Bot: {bot}")
 
         div = top / bot
 
         v2 = P * div
+
+        logging.info(f"Calc V2: div: {div} | v2: {v2}")
 
         return v2
 
@@ -302,8 +309,8 @@ class PrinterFssProbe:
 
         t1 = r2/v2
 
-        t2top = (L-r2) * 3 * u * A
-        t2bot = 2 * math.pi * P * pow(r2,3)
+        t2top = (L-r2)
+        t2bot = self._calc_v1(r2,P,u,A)
 
         ttot = t1 + (t2top/t2bot)
 
@@ -340,14 +347,16 @@ class PrinterFssProbe:
         return x
 
     def smart_dip(self, gcmd):
+        mPa_to_gfmm2 = .0000102
 
         viscosity_cps = gcmd.get_float("VISCOSITY", above=0.) #from resin profile
+        viscosity_gfmm2s = viscosity_cps * mPa_to_gfmm2
         resin_level_mm = self.last_resin_level
         surface_area_mm2 = gcmd.get_float("SURFACEAREA", above=0.) #from print data
         buildplate_area_mm2 = self.buildplate_area
         layerheight_mm = gcmd.get_float("LAYERHEIGHT", above=0.) # from slice data
         pressure_mpa = gcmd.get_float("PRESSURE", above=0.) #from resin profile
-        pressure_gfmm2 = pressure_mpa * .0000102
+        pressure_gfmm2 = pressure_mpa * mPa_to_gfmm2
         target_position = gcmd.get_float("TARGET", minval=0.)
 
         toolhead = self.printer.lookup_object('toolhead')
@@ -362,10 +371,10 @@ class PrinterFssProbe:
             surface_area_mm2 = min(surface_area_mm2,buildplate_area_mm2)
             logging.info(f"Offset surface area to {surface_area_mm2}, factor {build_area_factor}")
 
-        v2 = self._calc_v2(pressure_gfmm2,layerheight_mm,viscosity_cps,surface_area_mm2)
-        r2 = self._optimize_r2(v2,viscosity_cps,surface_area_mm2, pressure_gfmm2,dip_amount)
+        v2 = self._calc_v2(pressure_gfmm2,layerheight_mm,viscosity_gfmm2s,surface_area_mm2)
+        r2 = self._optimize_r2(v2,viscosity_gfmm2s,surface_area_mm2, pressure_gfmm2,dip_amount)
         r1 = dip_amount - r2
-        v1 = self._calc_v1(r2,pressure_gfmm2,viscosity_cps,surface_area_mm2)
+        v1 = self._calc_v1(r2,pressure_gfmm2,viscosity_gfmm2s,surface_area_mm2)
 
         logging.info(f"Two-Stage Retract calculated: R1: {r1} | V1: {v1} | R2: {r2} | V2: {v2}")
 
@@ -375,9 +384,9 @@ class PrinterFssProbe:
         pos2 = pos1
         pos2[2] -= r2
 
-        toolhead.manual_move(pos1, v1)
-        toolhead.manual_move(pos2, v2)
-
+        toolhead.move(pos1, v1)
+        toolhead.move(pos2, v2)
+        toolhead.wait_moves()
         pos = toolhead.get_position()
 
         return pos

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -332,7 +332,7 @@ class PrinterFssProbe:
             speed = round((minSpeed + (lift_speed - minSpeed) * (1-areaFactor)) , 2)
 
 
-        stage1Speed = min(stage1_max_speed, round(speed * 0.15 * (1 / modulus_gpa) / 5) * 5)
+        stage1Speed = min(stage1_max_speed, round(speed * 0.15 * (1 / modulus_gpa),2))
         stage2Speed = min(stage2_max_speed, speed)
 
         actual_lift_distance = stage1_distance + stage2_distance # recompute due to likely changes in previous code

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -165,7 +165,7 @@ class PrinterFssProbe:
 
         phoming = self.printer.lookup_object('homing')
         pos = self._get_position()
-        opos = pos[2]
+        opos = pos[2] + self.z_offset
         pos[2] += amount + self.z_offset
         epos = [pos[0], pos[1], pos[2]]
         try:
@@ -397,10 +397,14 @@ class PrinterFssProbe:
                 else:
                     pd_trigger_position = actual_lift_distance
 
+
+                pos = [0.0, 0.0, pd_trigger_position]
+
+
             else:
-                logging.warning(f"Smart Peel - Above Resin Level - PeelDetection Triggered")
+                logging.warning(f"Smart Peel - Above Resin Level - PeelDetection Triggered in first stage")
                 pd_trigger_position = stage1_distance
-                pos = [0.0, 0.0, actual_lift_distance]
+                pos = [0.0, 0.0, pd_trigger_position]
                 self._move(end_position, self.full_lift_speed)
 
         else:

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -401,7 +401,7 @@ class PrinterFssProbe:
         pos = self._get_position()
 
         if move_absolute == 1:
-            dip_amount = (pos[2] - dip_amount) *-1
+            dip_amount = (pos[2] - dip_amount)
 
         if dip_amount == 0:
             dip_amount = -1*pos[2]

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -147,8 +147,9 @@ class PrinterFssProbe:
 
     def _move(self, position, speed):
         toolhead = self.printer.lookup_object('toolhead')
-        position[2] += self.z_offset
-        toolhead.move(position,speed)
+        p = position.copy()
+        p[2] += self.z_offset
+        toolhead.move(p,speed)
 
     def _get_position(self):
         toolhead = self.printer.lookup_object('toolhead')
@@ -457,11 +458,11 @@ class PrinterFssProbe:
         dip_amount = pos[2] - target_position
 
         dip_first_stage = dip_amount * 0.8
-        dip_second_stage = dip_amount - dip_first_stage
+        dip_second_stage = dip_amount * 0.2
 
-        first_stage_target_position = pos.copy()
+        first_stage_target_position = [0. , 0. , 0. , 0.]
 
-        first_stage_target_position[2] -=  dip_first_stage
+        first_stage_target_position[2] =  target_position + dip_second_stage
         self._move(first_stage_target_position,vmax)
 
 
@@ -641,7 +642,8 @@ class PrinterFssProbe:
 
     cmd_SET_Z_OFFSET_help = "Sets the z-offset for probing and smart moves"
     def cmd_SET_Z_OFFSET(self,gcmd):
-        self.z_offset = gcmd.get_float("OFFSET", 0 , minval=0. )
+        self.z_offset = gcmd.get_float("OFFSET", 0.0 , minval=0. )
+        logging.info(f"Update Z-Offset to: {self.z_offset}")
 
     cmd_EXPOSE_help = "Exposes a layer for a given time with a given PWM setting"
     def cmd_EXPOSE(self, gcmd):

--- a/fss_probe.py
+++ b/fss_probe.py
@@ -327,18 +327,18 @@ class PrinterFssProbe:
 
         return v2
 
-    def _calc_ttot(self,r2,v2,u,A,P,L):
+    def _calc_ttot(self,r2,v2,u,A,P,L,v1p1,v1p2):
 
         t1 = r2/v2
 
         t2top = (L-r2)
-        t2bot = self._calc_v1(r2,P,u,A)
+        t2bot = self._calc_v1(r2,P,u,A,v1p1,v1p2)
 
         ttot = t1 + (t2top/t2bot)
 
         return ttot
 
-    def _optimize_r2(self,v2,u,A,P,L,tolerance=1e-8, max_iterations=1000):
+    def _optimize_r2(self,v2,u,A,P,L,v1p1,v1p2,tolerance=1e-8, max_iterations=1000):
 
 
         invphi = (math.sqrt(5) - 1) / 2  # 1/phi
@@ -349,8 +349,8 @@ class PrinterFssProbe:
 
         c = a + invphi2 * (b - a)
         d = a + invphi * (b - a)
-        fc = self._calc_ttot(c,v2, u, A, P, L)
-        fd = self._calc_ttot(d,v2, u, A, P, L)
+        fc = self._calc_ttot(c,v2, u, A, P, L,v1p1,v1p2)
+        fd = self._calc_ttot(d,v2, u, A, P, L,v1p1,v1p2)
 
         it = 0
         while (b - a) > tolerance and it < max_iterations:
@@ -358,11 +358,11 @@ class PrinterFssProbe:
             if fc < fd:
                 b, d, fd = d, c, fc
                 c = a + invphi2 * (b - a)
-                fc = self._calc_ttot(c,v2, u, A, P, L)
+                fc = self._calc_ttot(c,v2, u, A, P, L,v1p1,v1p2)
             else:
                 a, c, fc = c, d, fd
                 d = a + invphi * (b - a)
-                fd = self._calc_ttot(d,v2, u, A, P, L)
+                fd = self._calc_ttot(d,v2, u, A, P, L,v1p1,v1p2)
 
         x = (a + b) / 2
         logging.info(f"Completed Optimization after {it} iterations")
@@ -404,7 +404,7 @@ class PrinterFssProbe:
             pressure_mpa = pressure_gfmm2/mPa_to_gfmm2
 
         v2 = max(vmin,self._calc_v2(pressure_mpa,pressure_gfmm2,layerheight_mm,viscosity_cps,surface_area_mm2,v2p1))
-        r2 = self._optimize_r2(v2,viscosity_cps,surface_area_mm2, pressure_mpa,dip_amount)
+        r2 = self._optimize_r2(v2,viscosity_cps,surface_area_mm2, pressure_mpa,dip_amount,v1p1,v1p2)
         r1 = dip_amount - r2
         v1 = max(vmin,self._calc_v1(r2,pressure_mpa,viscosity_cps,surface_area_mm2,v1p1,v1p2))
 

--- a/pulse_out.py
+++ b/pulse_out.py
@@ -1,0 +1,67 @@
+# Force Sensor Probe support for MSLA Printers
+#
+# Copyright (C) 2022  Pascal Wistinghausen (pascal.wistinghausen@ib-wistinghausen.de)
+# Based on previous works by Kevin O'Connor
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+import pins
+
+
+class PulseOut:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name()
+
+        self.output_name = config.get(""
+                                      "output_name")
+
+        self.toolhead = self.printer.lookup_object('toolhead')
+        self.output = self.printer.lookup_object(f'output_pin {self.output_name}')
+
+
+        self.report_finished = config.getboolean("report_finished",False)
+
+        self.last_pulse_out_time = 0
+        self.last_pulse_out_power = 0
+        self.last_pulse_out_pre_delay = 0
+        self.last_pulse_out_post_delay = 0
+        self.last_gcmd = None
+
+        self.pulse_out_processing_delay = 0.300
+
+        self.reactor = self.printer.get_reactor()
+
+        # Register PROBE/QUERY_PROBE commands
+        self.gcode = self.printer.lookup_object('gcode')
+
+        self.gcode.register_mux_command("PULSE_OUT", "NAME",
+                                        self.name, self.cmd_PULSE_OUT,
+                                        desc=self.cmd_PULSE_OUT_help)
+
+
+    def pulse_out_timing_callback(self, print_time):
+        reactor_time = self.reactor.monotonic()
+
+        self.reactor.register_callback(self.pulse_out_done_callback, reactor_time + self.last_pulse_out_time + self.pulse_out_processing_delay * 2 + self.last_pulse_out_pre_delay + self.last_pulse_out_post_delay)
+
+        self.output.mcu_pin.set_pwm(print_time + self.pulse_out_processing_delay + self.last_pulse_out_pre_delay, self.last_pulse_out_power)
+        self.output.mcu_pin.set_pwm(print_time + self.pulse_out_processing_delay + self.last_pulse_out_pre_delay + self.last_pulse_out_time, 0)
+
+    def pulse_out_done_callback(self, print_time):
+        if self.report_finished:
+            self.last_gcmd.respond_raw("Z_move_comp")
+
+
+    cmd_PULSE_OUT_help = ""
+    def cmd_PULSE_OUT(self, gcmd):
+        self.last_pulse_out_power = gcmd.get_float("PWM", 0.1, above=0.)
+        self.last_pulse_out_time = gcmd.get_float("TIME", 1.0, above=0.)
+        self.last_pulse_out_pre_delay = gcmd.get_float("PRE_DELAY", 0)
+        self.last_pulse_out_post_delay = gcmd.get_float("POST_DELAY", 0)
+        self.last_gcmd = gcmd
+
+        self.toolhead.register_lookahead_callback(self.pulse_out_timing_callback)
+
+def load_config_prefix(config):
+    return PulseOut(config)

--- a/pulse_out.py
+++ b/pulse_out.py
@@ -13,11 +13,10 @@ class PulseOut:
         self.printer = config.get_printer()
         self.name = config.get_name()
 
-        self.output_name = config.get(""
-                                      "output_name")
+        self.output_name = config.get("output_name")
 
-        self.toolhead = self.printer.lookup_object('toolhead')
-        self.output = self.printer.lookup_object(f'output_pin {self.output_name}')
+        self.toolhead = None
+        self.output = None
 
 
         self.report_finished = config.getboolean("report_finished",False)
@@ -38,6 +37,14 @@ class PulseOut:
         self.gcode.register_mux_command("PULSE_OUT", "NAME",
                                         self.name, self.cmd_PULSE_OUT,
                                         desc=self.cmd_PULSE_OUT_help)
+
+        self.printer.register_event_handler("klippy:connect",
+                                            self.handle_connect)
+
+
+    def handle_connect(self):
+        self.toolhead = self.printer.lookup_object('toolhead')
+        self.output = self.printer.lookup_object(f'output_pin {self.output_name}')
 
 
     def pulse_out_timing_callback(self, print_time):

--- a/pulse_out.py
+++ b/pulse_out.py
@@ -29,6 +29,8 @@ class PulseOut:
 
         self.pulse_out_processing_delay = 0.300
 
+        self.pulse_out_active = False
+
         self.reactor = self.printer.get_reactor()
 
         # Register PROBE/QUERY_PROBE commands
@@ -56,18 +58,24 @@ class PulseOut:
         self.output.mcu_pin.set_pwm(print_time + self.pulse_out_processing_delay + self.last_pulse_out_pre_delay + self.last_pulse_out_time, 0)
 
     def pulse_out_done_callback(self, print_time):
+        self.pulse_out_active = False
         if self.report_finished:
             self.last_gcmd.respond_raw("Z_move_comp")
 
 
     cmd_PULSE_OUT_help = ""
     def cmd_PULSE_OUT(self, gcmd):
+
+        if self.pulse_out_active:
+            logging.warning("Exposure already running, please try again later")
+            return
+
         self.last_pulse_out_power = gcmd.get_float("PWM", 0.1, above=0.)
         self.last_pulse_out_time = gcmd.get_float("TIME", 1.0, above=0.)
         self.last_pulse_out_pre_delay = gcmd.get_float("PRE_DELAY", 0)
         self.last_pulse_out_post_delay = gcmd.get_float("POST_DELAY", 0)
         self.last_gcmd = gcmd
-
+        self.pulse_out_active = True
         self.toolhead.register_lookahead_callback(self.pulse_out_timing_callback)
 
 def load_config_prefix(config):

--- a/pulse_out.py
+++ b/pulse_out.py
@@ -78,5 +78,11 @@ class PulseOut:
         self.pulse_out_active = True
         self.toolhead.register_lookahead_callback(self.pulse_out_timing_callback)
 
+
+    def get_status(self, eventtime):
+        return {
+            'none': True
+        }
+
 def load_config_prefix(config):
     return PulseOut(config)

--- a/z_only.py
+++ b/z_only.py
@@ -74,7 +74,7 @@ class ZonlyKinematics:
 
     def set_position(self, newpos, homing_axes):
         self.z_rail.set_position(newpos)
-        if 2 in homing_axes:
+        if "z" in homing_axes:
             self.limit = self.z_rail.get_range()
 
     def clear_homing_state(self, clear_axes):

--- a/z_only.py
+++ b/z_only.py
@@ -107,7 +107,7 @@ class ZonlyKinematics:
         self.save_peel_decel = self.peel_decel
         self.save_dip_decel = self.dip_decel
 
-        self.peel_accel = self.homing_accel_decel
+        #self.peel_accel = self.homing_accel_decel
         self.dip_accel = self.homing_accel_decel
         self.peel_decel = self.homing_accel_decel
         self.dip_decel = self.homing_accel_decel

--- a/z_only.py
+++ b/z_only.py
@@ -175,9 +175,9 @@ class ZonlyKinematics:
             accel_d = 0.5*move_accel*accel_t**2
             decel_d = 0.5*move_decel*decel_t**2
 
-            if (accel_d+decel_d) < abs(move.axes_d[2]):
-                reachable_z_velocity = test_v
-            else:
+            reachable_z_velocity = test_v
+
+            if (accel_d+decel_d) > abs(move.axes_d[2]):
                 break
 
         logging.info("Kinematics output reachable_velocity: %f accel: %f decel: %f ratio: %f" % (reachable_z_velocity, move_accel, move_decel, z_small_move_ratio))

--- a/z_only.py
+++ b/z_only.py
@@ -52,6 +52,11 @@ class ZonlyKinematics:
         self.axes_min = toolhead.Coord(0, 0, z_range[0], e=0.)
         self.axes_max = toolhead.Coord(0, 0, z_range[1], e=0.)
 
+        self.gcode = self.printer.lookup_object('gcode')
+
+        self.gcode.register_command('UPDATE_ACCEL_LIMITS', self.cmd_UPDATE_ACCEL_LIMITS)
+
+
     def get_steppers(self):
         return self.z_rail.get_steppers()
 
@@ -182,6 +187,14 @@ class ZonlyKinematics:
             'axis_minimum': self.axes_min,
             'axis_maximum': self.axes_max,
         }
+
+
+    def cmd_UPDATE_ACCEL_LIMITS(self, gcmd):
+        self.peel_accel = gcmd.get_float("PEEL_ACCEL", self.peel_accel, above=0.)
+        self.peel_decel = gcmd.get_float("PEEL_DECEL", self.peel_decel, above=0.)
+        self.dip_accel = gcmd.get_float("DIP_ACCEL", self.dip_accel, above=0.)
+        self.dip_decel = gcmd.get_float("DIP_DECEL", self.dip_decel, above=0.)
+        return True
 
 
 def load_kinematics(toolhead, config):

--- a/z_only.py
+++ b/z_only.py
@@ -168,17 +168,23 @@ class ZonlyKinematics:
 
         reachable_z_velocity = self.max_z_velocity
 
-        for i in range(1,int(self.max_z_velocity), 1):
-            test_v = float(i)
-            accel_t = test_v/move_accel
-            decel_t = test_v/move_decel
-            accel_d = 0.5*move_accel*accel_t**2
-            decel_d = 0.5*move_decel*decel_t**2
+        def calc_acceldecel_d(test_v_int, move_accel_int, move_decel_int):
+            accel_t_int = test_v_int/move_accel_int
+            decel_t_int = test_v_int/move_decel_int
+            accel_d_int = 0.5*move_accel_int*accel_t_int**2
+            decel_d_int = 0.5*move_decel_int*decel_t_int**2
+            return accel_d_int + decel_d_int
 
-            reachable_z_velocity = test_v
-
-            if (accel_d+decel_d) > abs(move.axes_d[2]):
+        for i in range(int(self.max_z_velocity),0, -1):
+            reachable_z_velocity = float(i)
+            if calc_acceldecel_d(reachable_z_velocity,move_accel, move_decel ) < abs(move.axes_d[2]):
                 break
+
+        if reachable_z_velocity == 0:
+            for i in range(10, 1, -1):
+                reachable_z_velocity = float(i)/10.0
+                if calc_acceldecel_d(reachable_z_velocity, move_accel, move_decel) < abs(move.axes_d[2]):
+                    break
 
         logging.info("Kinematics output reachable_velocity: %f accel: %f decel: %f ratio: %f" % (reachable_z_velocity, move_accel, move_decel, z_small_move_ratio))
 

--- a/z_only.py
+++ b/z_only.py
@@ -73,6 +73,7 @@ class ZonlyKinematics:
         self.peel_decel = data["peel_decel"]
         self.dip_accel = data["dip_accel"]
         self.dip_decel = data["dip_decel"]
+        logging.info(f"Update AccelDecel - PA: {self.peel_accel} | PD: {self.peel_decel} | DA: {self.dip_accel} | DD: {self.dip_decel}")
 
     def calc_position(self, stepper_positions):
         return [0, 0, stepper_positions[self.z_rail.get_name()]]
@@ -156,6 +157,8 @@ class ZonlyKinematics:
         else:
             move_accel = self.peel_accel
             move_decel = self.peel_decel
+
+        logging.info(f"Commanded AccelDecel: A: {move_accel} D: {move_decel}")
 
         z_small_move_ratio = min((abs(move.axes_d[2]) / 2), 1)
 

--- a/z_only.py
+++ b/z_only.py
@@ -43,6 +43,8 @@ class ZonlyKinematics:
         self.dip_decel = config.getfloat('dip_decel', max_accel,
                                          above=0., maxval=max_accel)
 
+        self.accel_decel_baseline = self.get_accel_decel()
+
         self.homing_accel_decel = config.getfloat('homing_accel_decel', max_accel / 10,
                                                   above=0., maxval=max_accel)
 
@@ -73,7 +75,10 @@ class ZonlyKinematics:
         self.peel_decel = data["peel_decel"]
         self.dip_accel = data["dip_accel"]
         self.dip_decel = data["dip_decel"]
-        logging.info(f"Update AccelDecel - PA: {self.peel_accel} | PD: {self.peel_decel} | DA: {self.dip_accel} | DD: {self.dip_decel}")
+        #logging.info(f"Update AccelDecel - PA: {self.peel_accel} | PD: {self.peel_decel} | DA: {self.dip_accel} | DD: {self.dip_decel}")
+
+    def reset_accel_decel(self):
+        self.set_accel_decel(self.accel_decel_baseline)
 
     def calc_position(self, stepper_positions):
         return [0, 0, stepper_positions[self.z_rail.get_name()]]
@@ -158,7 +163,7 @@ class ZonlyKinematics:
             move_accel = self.peel_accel
             move_decel = self.peel_decel
 
-        logging.info(f"Commanded AccelDecel: A: {move_accel} D: {move_decel}")
+        #logging.info(f"Commanded AccelDecel: A: {move_accel} D: {move_decel}")
 
         z_small_move_ratio = min((abs(move.axes_d[2]) / 2), 1)
 
@@ -186,7 +191,7 @@ class ZonlyKinematics:
                 if calc_acceldecel_d(reachable_z_velocity, move_accel, move_decel) < abs(move.axes_d[2]):
                     break
 
-        logging.info("Kinematics output reachable_velocity: %f accel: %f decel: %f ratio: %f" % (reachable_z_velocity, move_accel, move_decel, z_small_move_ratio))
+        #logging.info("Kinematics output reachable_velocity: %f accel: %f decel: %f ratio: %f" % (reachable_z_velocity, move_accel, move_decel, z_small_move_ratio))
 
         move.limit_speed(reachable_z_velocity, move_accel * z_ratio, move_decel * z_ratio)
 


### PR DESCRIPTION
Using low values for part strength (below 1) leaded to high stage 1 distances in the actual code.
This leads to long layer times because the slow speed in stage 1.

I think we don't need more than 2.5 mm lift before the print detaches. So I suggest to limit the stage 1 distance to 2.5 instead of lift from profile -1.

Instead I increased the total lift distance by 1 to compensate for it and make sure the layer releases all times. But now the higher speed in stage 2 (up to full_lift_speed if a peel event was detected) is used for this extra assurance distance.

Suggested change:
<img width="706" height="516" alt="Bildschirmfoto 2026-03-19 um 17 14 09" src="https://github.com/user-attachments/assets/883afd0e-e889-4ab5-94a3-5c9f0bdd46a8" />

Before:
<img width="656" height="354" alt="Bildschirmfoto 2026-03-19 um 17 16 27" src="https://github.com/user-attachments/assets/ffce3b4c-d493-49f5-971e-d46189eee8fd" />

